### PR TITLE
Configure persistent web sessions with 7-day cookie expiration

### DIFF
--- a/src/main/kotlin/com/github/derminator/archipelobby/WebSessionConfiguration.kt
+++ b/src/main/kotlin/com/github/derminator/archipelobby/WebSessionConfiguration.kt
@@ -18,14 +18,12 @@ class WebSessionConfiguration {
     }
 
     @Bean
-    fun webSessionIdResolver(): WebSessionIdResolver {
-        val resolver = CookieWebSessionIdResolver()
-        resolver.addCookieInitializer { cookie ->
+    fun webSessionIdResolver(): WebSessionIdResolver = CookieWebSessionIdResolver().apply {
+        addCookieInitializer { cookie ->
             cookie.maxAge(SESSION_DURATION)
             cookie.httpOnly(true)
             cookie.sameSite("Lax")
         }
-        return resolver
     }
 
     @Bean

--- a/src/test/kotlin/com/github/derminator/archipelobby/WebTests.kt
+++ b/src/test/kotlin/com/github/derminator/archipelobby/WebTests.kt
@@ -1,6 +1,5 @@
 package com.github.derminator.archipelobby
 
-import com.github.derminator.archipelobby.WebSessionConfiguration
 import com.github.derminator.archipelobby.data.Entry
 import com.github.derminator.archipelobby.data.EntryRepository
 import com.github.derminator.archipelobby.data.Room


### PR DESCRIPTION
## Summary
This PR adds explicit web session configuration to enable persistent sessions with a 7-day expiration window, and includes a test to verify the session cookie behavior after form login.

## Key Changes
- **New `WebSessionConfiguration` class**: Configures Spring WebFlux session management with:
  - `CookieWebSessionIdResolver` that sets session cookies with a 7-day max age
  - Cookie security settings: `httpOnly=true` and `sameSite=Lax`
  - Custom `InMemoryWebSessionStore` that sets session idle timeout to 7 days
  - Centralized `SESSION_DURATION` constant for consistency

- **New test `session cookie is persistent after form login`**: Verifies that:
  - Login responses include a session cookie with a positive max-age value
  - The cookie's max-age is at least 7 days
  - The session cookie can be used to access protected resources

## Implementation Details
- Uses Spring WebFlux's reactive session API with `Mono` for async operations
- Session persistence is achieved through both cookie max-age and server-side session idle time configuration
- The test validates the complete session lifecycle: login → cookie creation → authenticated request

https://claude.ai/code/session_01SRXXRwUPVUDY6Q6axEmkFW