### PR TITLE
Add public room preview with Open Graph tags for Discord link previews

### DIFF
--- a/src/main/kotlin/com/github/derminator/archipelobby/SecurityConfiguration.kt
+++ b/src/main/kotlin/com/github/derminator/archipelobby/SecurityConfiguration.kt
@@ -3,6 +3,7 @@ package com.github.derminator.archipelobby
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.core.env.Environment
+import org.springframework.http.HttpMethod
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity
 import org.springframework.security.config.web.server.ServerHttpSecurity
 import org.springframework.security.config.web.server.invoke
@@ -36,6 +37,7 @@ class SecurityConfiguration(
         return http {
             authorizeExchange {
                 authorize(pathMatchers("/", "/error", "/style.css", "/robots.txt", "/favicon.svg"), permitAll)
+                authorize(pathMatchers(HttpMethod.GET, "/rooms/*"), permitAll)
                 authorize(anyExchange(), authenticated)
             }
             if (isDiscordEnabled) {

--- a/src/main/kotlin/com/github/derminator/archipelobby/controllers/RoomController.kt
+++ b/src/main/kotlin/com/github/derminator/archipelobby/controllers/RoomController.kt
@@ -80,9 +80,14 @@ class RoomController(
     @GetMapping("/{roomId}")
     fun getRoom(
         @PathVariable roomId: Long,
-        principal: Principal,
+        principal: Principal?,
         model: Model
     ): Mono<String> = mono {
+        if (principal == null) {
+            val preview = roomService.getRoomForPreview(roomId)
+            model.addAttribute("preview", preview)
+            return@mono "room-preview"
+        }
         val userId = principal.asDiscordPrincipal.userId
         loadRoomModel(roomId, userId, model)
         "room"

--- a/src/main/kotlin/com/github/derminator/archipelobby/data/RoomService.kt
+++ b/src/main/kotlin/com/github/derminator/archipelobby/data/RoomService.kt
@@ -227,8 +227,17 @@ class RoomService(
 
         apWorldRepository.deleteById(apWorldId).awaitSingleOrNull()
     }
+
+    suspend fun getRoomForPreview(roomId: Long): RoomPreview {
+        val room = roomRepository.findById(roomId).awaitSingleOrNull()
+            ?: throw ResponseStatusException(HttpStatus.NOT_FOUND)
+        val entries = entryRepository.findByRoomId(roomId).asFlow().toList()
+        val games = entries.map { it.game }.distinct().sorted()
+        return RoomPreview(room.name, entries.size, games)
+    }
 }
 
+data class RoomPreview(val name: String, val entryCount: Int, val games: List<String>)
 data class ApWorldFile(val fileName: String, val filePath: String)
 data class EntryInfo(val id: Long, val name: String, val game: String, val user: UserInfo)
 data class ApWorldInfo(val id: Long, val fileName: String, val user: UserInfo)

--- a/src/main/resources/templates/room-preview.html
+++ b/src/main/resources/templates/room-preview.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta property="og:type" content="website">
+    <meta property="og:title" th:content="${preview.name}">
+    <meta property="og:description" th:content="|${preview.entryCount} ${preview.entryCount == 1 ? 'entry' : 'entries'}${not #lists.isEmpty(preview.games) ? ': ' + #strings.listJoin(preview.games, ', ') : ''}|">
+    <title th:text="${preview.name}">Room</title>
+    <link rel="stylesheet" th:href="@{/style.css}">
+</head>
+<body>
+<header>
+    <div th:replace="~{layout :: user-bar}"></div>
+</header>
+<main>
+    <h1 th:text="${preview.name}">Room Name</h1>
+    <p>
+        <span th:text="${preview.entryCount}">0</span>
+        <span th:text="${preview.entryCount == 1 ? 'entry' : 'entries'}">entries</span>
+        <span th:if="${not #lists.isEmpty(preview.games)}">
+            — <span th:text="${#strings.listJoin(preview.games, ', ')}">Games</span>
+        </span>
+    </p>
+    <p><a th:href="@{/oauth2/authorization/discord}">Log in with Discord to view the full room</a></p>
+</main>
+</body>
+</html>

--- a/src/main/resources/templates/room.html
+++ b/src/main/resources/templates/room.html
@@ -2,6 +2,9 @@
 <html lang="en" xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
+    <meta property="og:type" content="website">
+    <meta property="og:title" th:content="${room.name}">
+    <meta property="og:description" th:content="|Archipelago room with ${#lists.size(entries)} entries|">
     <title th:text="${room.name}">Room Name</title>
     <link rel="stylesheet" th:href="@{/style.css}">
     <script th:src="@{/confirm.js}" defer></script>


### PR DESCRIPTION
When unauthenticated (e.g. Discord's link preview bot), GET /rooms/{id}
now returns a minimal preview page showing room name, entry count, and
game list — without exposing player usernames or guild info. Authenticated
users continue to see the full room page unchanged. OG meta tags on both
pages ensure Discord renders a useful embed instead of the login page.

https://claude.ai/code/session_014L6WEEX4TNGF1zjM28kp2P