### PR TITLE
Fix DuplicateKeyException when generating game for existing rooms

### DIFF
--- a/src/main/kotlin/com/github/derminator/archipelobby/data/Room.kt
+++ b/src/main/kotlin/com/github/derminator/archipelobby/data/Room.kt
@@ -13,7 +13,7 @@ data class Room(
     val guildId: Long,
     val name: String,
     val generatedGameFilePath: String? = null,
-    @Version val version: Long = 0,
+    @Version val version: Long? = null,
 ) {
     companion object {
         const val GENERATING_SENTINEL = "__generating__"


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Fixes #49
- Spring Data R2DBC treats `@Version Long` (non-nullable) with value `0` as a **new** entity and issues an `INSERT` instead of an `UPDATE`. Since all rooms have `version = 0` after the V5 migration (and after initial creation), every call to `generateGame()` triggered an `INSERT` that collided with the existing primary key.
- Fix: change `@Version val version: Long = 0` → `@Version val version: Long? = null` in `Room.kt`. With a nullable `Long?`, Spring Data only treats an entity as new when version is `null` (i.e. never-persisted), while any non-null value (including `0`) correctly triggers an `UPDATE`.

## Test plan

- [ ] Create a room and add at least one entry
- [ ] Click "Generate" — should succeed without a `DuplicateKeyException`
- [ ] Verify optimistic locking still works: concurrent generate attempts should receive a 409 Conflict rather than a stack trace

https://claude.ai/code/session_01QNcRgRmDCT8hsJbN77XE7w
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QNcRgRmDCT8hsJbN77XE7w)_