### PR TITLE
Run ModuleUpdate before each generation to install APWorld dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,6 +11,8 @@ group = "com.github.derminator"
 version = "0.0.1-SNAPSHOT"
 description = "archipelobby"
 
+private val mockitoAgent = configurations.create("mockitoAgent")
+
 java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(25)
@@ -53,6 +55,7 @@ dependencies {
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+    mockitoAgent("org.mockito:mockito-core") { isTransitive = false }
 }
 
 kotlin {
@@ -68,4 +71,10 @@ springBoot {
 
 tasks.withType<Test> {
     useJUnitPlatform()
+}
+
+tasks {
+    test {
+        jvmArgs.add("-javaagent:${mockitoAgent.asPath}")
+    }
 }

--- a/src/main/kotlin/com/github/derminator/archipelobby/generator/RealArchipelagoGeneratorService.kt
+++ b/src/main/kotlin/com/github/derminator/archipelobby/generator/RealArchipelagoGeneratorService.kt
@@ -43,6 +43,13 @@ class RealArchipelagoGeneratorService(
                 customWorldsDir.resolve(name).writeBytes(bytes)
             }
 
+            // Install any dependencies introduced by the current set of APWorlds.
+            val moduleUpdateFile = File(moduleUpdateScriptPath).absoluteFile
+            pythonScriptRunner.run(
+                workDir.resolve(moduleUpdateFile.name).path,
+                "--yes",
+            )
+
             pythonScriptRunner.run(
                 workDir.resolve(scriptFile.name).path,
                 "--player_files_path", playersDir.path,


### PR DESCRIPTION
## Summary

- Fixes #50: game generation failing when APWorld files introduce Python dependencies not installed at startup
- `ModuleUpdate.py --yes` now runs in the temp work directory **before** `Generate.py`, after APWorld files have been written to `custom_worlds/`
- The startup `@PostConstruct` install is retained for fast eager initialization of base Archipelago dependencies

## Root Cause

`ModuleUpdate.py --yes` was only called once at application startup. If an APWorld uploaded after startup required packages not yet in the venv, `Generate.py` would fail trying to import them (or fail calling `ModuleUpdate` internally without the `--yes` flag).

## Test plan

- [ ] Run `./gradlew test` — existing tests pass
- [ ] Upload an APWorld with a dependency absent at startup, trigger generation, confirm it succeeds
- [ ] Confirm generation still works with no APWorld files (ModuleUpdate `--yes` is a no-op when nothing new is needed)

https://claude.ai/code/session_01WFsDuGJ3Ke27V5RFZun9h9

---
_Generated by [Claude Code](https://claude.ai/code/session_01WFsDuGJ3Ke27V5RFZun9h9)_