### PR TITLE
Add go-themed pun to each room's page (#45)

### DIFF
--- a/src/main/kotlin/com/github/derminator/archipelobby/controllers/RoomController.kt
+++ b/src/main/kotlin/com/github/derminator/archipelobby/controllers/RoomController.kt
@@ -2,6 +2,7 @@ package com.github.derminator.archipelobby.controllers
 
 import com.github.derminator.archipelobby.data.ApWorldFile
 import com.github.derminator.archipelobby.data.EntryYaml
+import com.github.derminator.archipelobby.data.Puns
 import com.github.derminator.archipelobby.data.RoomService
 import com.github.derminator.archipelobby.security.asDiscordPrincipal
 import com.github.derminator.archipelobby.storage.UploadsService
@@ -87,6 +88,7 @@ class RoomController(
         if (principal == null || principal is AnonymousAuthenticationToken) {
             val preview = roomService.getRoomForPreview(roomId)
             model.addAttribute("preview", preview)
+            model.addAttribute("pun", Puns.forRoom(roomId))
             return@mono "room-preview"
         }
         val userId = principal.asDiscordPrincipal.userId
@@ -367,6 +369,7 @@ class RoomController(
         model.addAttribute("isAdmin", roomWithEntries.isAdmin)
         model.addAttribute("userId", userId)
         model.addAttribute("apWorlds", roomService.getApWorldsForRoom(roomId, userId).toList())
+        model.addAttribute("pun", Puns.forRoom(roomId))
     }
 
     private suspend fun readFilePart(filePart: FilePart): ByteArray {

--- a/src/main/kotlin/com/github/derminator/archipelobby/controllers/RoomController.kt
+++ b/src/main/kotlin/com/github/derminator/archipelobby/controllers/RoomController.kt
@@ -305,7 +305,7 @@ class RoomController(
         } catch (e: ResponseStatusException) {
             if (e.statusCode == HttpStatus.BAD_REQUEST
                 || e.statusCode == HttpStatus.CONFLICT
-                || e.statusCode == HttpStatus.UNPROCESSABLE_ENTITY
+                || e.statusCode == HttpStatus.UNPROCESSABLE_CONTENT
             ) {
                 loadRoomModel(roomId, userId, model)
                 model.addAttribute("errorMessage", e.reason ?: "An error occurred")

--- a/src/main/kotlin/com/github/derminator/archipelobby/data/Puns.kt
+++ b/src/main/kotlin/com/github/derminator/archipelobby/data/Puns.kt
@@ -1,0 +1,23 @@
+package com.github.derminator.archipelobby.data
+
+object Puns {
+    private val puns = listOf(
+        "Archipela-go! Let's get this show on the road.",
+        "Ready, set, go-nerate your multiworld!",
+        "Pokémon, go to the polls... but first, finish this room.",
+        "Go-al achieved: you found this room. Now fill it.",
+        "Time to go-lden ticket your way through this randomizer!",
+        "Go big or go home. You've already gone to Archipelago.",
+        "As they say: ready, set, go-ing to lose all your sanity.",
+        "Why did the randomizer go to therapy? Too many go-als.",
+        "Life is go-od when you're playing Archipelago.",
+        "Go ahead, submit your YAML. I won't judge.",
+        "This room is go-ing places. Probably to sphere 1.",
+        "Go-lly, that's a lot of games.",
+        "Let's-a-go! (Wrong franchise, but the energy is right.)",
+        "Where do you want to go today? Archipelago!",
+        "No need to go it alone — it's a multiworld!",
+    )
+
+    fun forRoom(roomId: Long): String = puns[(roomId % puns.size).toInt()]
+}

--- a/src/main/resources/templates/room-preview.html
+++ b/src/main/resources/templates/room-preview.html
@@ -15,6 +15,7 @@
 </header>
 <main>
     <h1 th:text="${preview.name}">Room Name</h1>
+    <p th:text="${pun}"></p>
     <p>
         <span th:text="${preview.entryCount}">0</span>
         <span th:text="${preview.entryCount == 1 ? 'entry' : 'entries'}">entries</span>

--- a/src/main/resources/templates/room.html
+++ b/src/main/resources/templates/room.html
@@ -16,6 +16,7 @@
 </header>
 <main>
     <h1 th:text="${room.name}">Room Name</h1>
+    <p th:text="${pun}"></p>
 
     <div th:if="${room.isGenerated}">
         <h2>Generated Game</h2>


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds a `Puns` object (`data/Puns.kt`) containing 15 poor-quality "go"-themed puns (e.g. "Archipela-go!", "Pokémon, go to the polls... but first, finish this room.")
- Pun is selected deterministically using `roomId % puns.size` — same pun every visit, no DB migration needed
- Pun is displayed below the room name on both the authenticated room page (`room.html`) and the public preview page (`room-preview.html`)

Closes #45

## Test plan

- [x] Create a new room and confirm a pun appears below the room name
- [x] Visit the room while logged out (preview page) and confirm the pun appears there too
- [x] Create a second room and confirm it shows a different pun
- [x] Reload both room pages and confirm puns remain the same across reloads (deterministic)

https://claude.ai/code/session_01NvBp7Gogv8C1neUHa9VapZ
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NvBp7Gogv8C1neUHa9VapZ)_