### PR TITLE
Add Dev Container configuration

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -12,3 +12,5 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN python3 -m venv /opt/venv && /opt/venv/bin/pip install --upgrade pip
 
 ENV ARCHIPELOBBY_PYTHON_EXECUTABLE=/opt/venv/bin/python
+
+USER root

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,14 @@
+FROM docker.io/library/eclipse-temurin:25-jdk
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    curl \
+    ca-certificates \
+    python3 \
+    python3-venv \
+    python3-pip \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN python3 -m venv /opt/venv && /opt/venv/bin/pip install --upgrade pip
+
+ENV ARCHIPELOBBY_PYTHON_EXECUTABLE=/opt/venv/bin/python

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,28 @@
+{
+  "name": "Archipelobby",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "forwardPorts": [8080],
+  "portsAttributes": {
+    "8080": {
+      "label": "Spring Boot",
+      "onAutoForward": "notify"
+    }
+  },
+  "customizations": {
+    "jetbrains": {
+      "backend": "IntelliJIdea"
+    },
+    "vscode": {
+      "extensions": [
+        "mathiasfrohlich.Kotlin",
+        "vscjava.vscode-gradle"
+      ]
+    }
+  },
+  "remoteEnv": {
+    "ARCHIPELOBBY_PYTHON_EXECUTABLE": "/opt/venv/bin/python"
+  },
+  "postCreateCommand": "./gradlew dependencies --no-daemon -q"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -21,6 +21,7 @@
       ]
     }
   },
+  "remoteUser": "root",
   "remoteEnv": {
     "ARCHIPELOBBY_PYTHON_EXECUTABLE": "/opt/venv/bin/python"
   },


### PR DESCRIPTION
## Summary
- Adds `.devcontainer/Dockerfile` based on `docker.io/library/eclipse-temurin:25-jdk` (matching the production image), with Python 3 and a pre-created venv at `/opt/venv` for Archipelago dependencies
- Adds `.devcontainer/devcontainer.json` with IntelliJ Gateway support (`customizations.jetbrains.backend`), port 8080 forwarded, `remoteUser: root` for Podman compatibility, and a `postCreateCommand` to warm the Gradle dependency cache

## Test plan
- [ ] Open project via JetBrains Gateway → Dev Containers and verify the container builds and IDE connects
- [ ] Confirm `ARCHIPELOBBY_PYTHON_EXECUTABLE` resolves to `/opt/venv/bin/python` inside the container
- [ ] Verify port 8080 is forwarded when the app is started with `./gradlew bootRun`

🤖 Generated with [Claude Code](https://claude.com/claude-code)