### PR TITLE
Pin eclipse-temurin base images to -noble to avoid Python 3.14

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/eclipse-temurin:25-jdk
+FROM docker.io/library/eclipse-temurin:25-jdk-noble
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage: plain JDK, no native-image
-FROM eclipse-temurin:25-jdk AS build
+FROM eclipse-temurin:25-jdk-noble AS build
 WORKDIR /app
 COPY . ./
 ARG SPRING_PROFILE=prod
@@ -7,7 +7,7 @@ ENV SPRING_PROFILES_ACTIVE=${SPRING_PROFILE}
 RUN ./gradlew bootJar --no-daemon
 
 # Run stage: JRE + CPython
-FROM eclipse-temurin:25-jre
+FROM eclipse-temurin:25-jre-noble
 WORKDIR /app
 
 RUN groupadd -r -g 10001 appuser && useradd -r -u 10001 -g appuser appuser


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- `eclipse-temurin:25-jre` and `eclipse-temurin:25-jdk` were recently rebased onto Ubuntu 26.04, which ships Python 3.14 as the default `python3`
- Archipelago only supports Python 3.11–3.13, causing runtime failures
- Pins both `Dockerfile` and `.devcontainer/Dockerfile` to the `-noble` variant (Ubuntu 24.04), which ships Python 3.12

## Test plan

- [ ] Build the Docker image and confirm `python3 --version` reports 3.12.x
- [ ] Verify Archipelago game generation works end-to-end in the container

https://claude.ai/code/session_01JoPEiEBVx2MTXLow5YtM64
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoPEiEBVx2MTXLow5YtM64)_