### PR TITLE
Fix ModuleUpdate interactive prompt crash when listing games

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN groupadd -r -g 10001 appuser && useradd -r -u 10001 -g appuser appuser
 RUN mkdir -p /data && chown -R appuser:appuser /data
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates python3 python3-venv python3-pip && \
+    ca-certificates python3 python3-venv python3-pip git cmake && \
     rm -rf /var/lib/apt/lists/*
 
 # Pre-create an empty venv so ModuleUpdate.py's pip install lands in a

--- a/python/list_games.py
+++ b/python/list_games.py
@@ -23,6 +23,8 @@ def _emit(payload):
 
 
 def _list_core_games():
+    if "--yes" not in sys.argv:
+        sys.argv.append("--yes")
     import ModuleUpdate
     ModuleUpdate.update()
 


### PR DESCRIPTION
## Summary

- `list_games.py` called `ModuleUpdate.update()` without `--yes`, so when packages like `zilliandomizer==0.9.1` were missing, `ModuleUpdate.confirm()` called `input()` — which raises `EOFError` because `PythonScriptRunner` closes stdin immediately. This crashed every room page view after upgrading to Archipelago 0.2.0.
- Added `--yes` to `sys.argv` before calling `update()` so ModuleUpdate auto-confirms, matching the behavior of `installDependencies()` at startup.
- Added `git` and `cmake` to the production Docker image so that the git-URL-based (`zilliandomizer`) and cmake-based (`dolphin-memory-engine`) packages can actually be installed by ModuleUpdate at startup rather than silently failing.

## Root cause detail

`RealArchipelagoGeneratorService.installDependencies()` already runs `ModuleUpdate.py --yes` at startup, which installs most packages. However, two packages require build tools not present in the image:
- `zilliandomizer==0.9.1` — installed via git URL, fails with `Cannot find command 'git'`
- `dolphin-memory-engine>=1.3.0` — requires cmake to build

These remained uninstalled. When the first room page loaded, `list_games.py` called `ModuleUpdate.update()` (no `--yes`) and hit the interactive prompt → EOFError → 500 error.

## Test plan

- [ ] Rebuild Docker image and navigate to a room page — game list should load without error
- [ ] Verify game list includes Zillion and Wind Waker (previously excluded due to missing build tools)
- [ ] Subsequent room views return instantly (cache hit)
- [ ] `./gradlew test` passes — `GameCatalogServiceTest` mocks `ModuleUpdate.update()` so no test changes needed

https://claude.ai/code/session_01RKBAmMKt6FvQRjLt75pvwW

---
_Generated by [Claude Code](https://claude.ai/code/session_01RKBAmMKt6FvQRjLt75pvwW)_