### PR TITLE
Fix Python package build failures and pip warnings on Docker startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,12 +14,14 @@ RUN groupadd -r -g 10001 appuser && useradd -r -u 10001 -g appuser appuser
 RUN mkdir -p /data && chown -R appuser:appuser /data
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates python3 python3-venv python3-pip git cmake && \
+    ca-certificates python3 python3-venv python3-pip git cmake build-essential && \
     rm -rf /var/lib/apt/lists/*
 
 # Pre-create an empty venv so ModuleUpdate.py's pip install lands in a
 # writable, PEP 668-clean location. Archipelago deps install on first run.
 RUN python3 -m venv /app/.venv && /app/.venv/bin/pip install --upgrade pip
+
+ENV PIP_NO_CACHE_DIR=1
 
 COPY --from=build /app/build/libs/*.jar app.jar
 COPY ./Archipelago ./Archipelago

--- a/src/main/kotlin/com/github/derminator/archipelobby/generator/PythonScriptRunner.kt
+++ b/src/main/kotlin/com/github/derminator/archipelobby/generator/PythonScriptRunner.kt
@@ -35,6 +35,7 @@ class PythonScriptRunner(
             .also {
                 it.environment()["PYTHONUNBUFFERED"] = "1"
                 it.environment()["DISPLAY"] = ""
+                it.environment()["PYTHONWARNINGS"] = "ignore::UserWarning:pkg_resources"
             }
             .start()
         process.outputStream.close()


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Add `build-essential` to Docker image** — provides `aarch64-linux-gnu-g++` and `make`, which are required to compile `materialyoucolor` and `dolphin-memory-engine`. These two packages were failing to build at container startup, which caused `list_games.py` to crash with `EOFError` (the packages remained uninstalled, `ModuleUpdate.update()` detected them missing, called `input()` for confirmation, but stdin is closed in the subprocess).
- **Set `PIP_NO_CACHE_DIR=1`** — eliminates the repeated `WARNING: The directory '/home/appuser/.cache/pip'...` messages. The `appuser` system user has no home directory, so pip's default cache path is never writable.
- **Suppress `pkg_resources` `UserWarning` via `PYTHONWARNINGS`** — this warning comes from Archipelago's submodule code (`ModuleUpdate.py`) which we don't own. Filtered at the subprocess level in `PythonScriptRunner`.

## Test plan

- [ ] Rebuild the Docker image and start the container
- [ ] Confirm startup logs show all packages installing without errors or warnings
- [ ] Confirm loading a room in the app no longer shows the `EOFError`/`DistributionNotFound` error
- [ ] Confirm no more `WARNING: The directory '/home/appuser/.cache/pip'` lines in logs

https://claude.ai/code/session_019fuzrM5wkmWdwvwaggMiUX
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_019fuzrM5wkmWdwvwaggMiUX)_