### PR TITLE
Add python3-dev to fix C extension build failures on startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN groupadd -r -g 10001 appuser && useradd -r -u 10001 -g appuser appuser
 RUN mkdir -p /data && chown -R appuser:appuser /data
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates python3 python3-venv python3-pip git cmake build-essential && \
+    ca-certificates python3 python3-venv python3-pip python3-dev git cmake build-essential && \
     rm -rf /var/lib/apt/lists/*
 
 # Pre-create an empty venv so ModuleUpdate.py's pip install lands in a


### PR DESCRIPTION
## Summary

- Add `python3-dev` to the Docker image's apt packages so that pip can compile C/C++ extensions at startup
- Without this, `materialyoucolor` (a transitive dep of `kivymd`) and `dolphin-memory-engine` (required by the TWW world) both fail to build their wheels because the compiler can't find `Python.h`
- This failure prevents rooms from loading

## Root cause

The run-stage Dockerfile already installs `build-essential` and `cmake`, giving the C/C++ compiler toolchain, but `python3-dev` (which provides `Python.h` and the Python 3.12 include directory) was missing. Any pip package that compiles a C extension against the CPython API needs this header.

## Test plan

- [ ] Build the Docker image and confirm startup logs show successful installs of `materialyoucolor` and `dolphin-memory-engine` instead of wheel build errors
- [ ] Confirm rooms load normally in the app

https://claude.ai/code/session_01RjeuuCA2rLWuDCiHvUr7X2

---
_Generated by [Claude Code](https://claude.ai/code/session_01RjeuuCA2rLWuDCiHvUr7X2)_