### PR TITLE
Fall back to Python discovery for APWorlds without archipelago.json

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Python 3
         uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          python-version: '3.13'
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,37 @@
+name: Tests
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Set up JDK 25
+        uses: actions/setup-java@v4
+        with:
+          java-version: '25'
+          distribution: 'temurin'
+
+      - name: Set up Python 3
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Run tests
+        run: ./gradlew test

--- a/src/main/kotlin/com/github/derminator/archipelobby/controllers/RoomController.kt
+++ b/src/main/kotlin/com/github/derminator/archipelobby/controllers/RoomController.kt
@@ -133,7 +133,7 @@ class RoomController(
             val pendingApWorld: Triple<String, ByteArray, String>? =
                 if (apworldFilePart != null && apworldFilePart.filename().isNotEmpty()) {
                     val apworldBytes = readFilePart(apworldFilePart)
-                    val gameName = gameCatalogService.extractApWorldGame(apworldBytes)
+                    val gameName = gameCatalogService.extractApWorldGame(apworldBytes, apworldFilePart.filename())
                     Triple(apworldFilePart.filename(), apworldBytes, gameName)
                 } else null
 

--- a/src/main/kotlin/com/github/derminator/archipelobby/generator/GameCatalogService.kt
+++ b/src/main/kotlin/com/github/derminator/archipelobby/generator/GameCatalogService.kt
@@ -49,38 +49,79 @@ class GameCatalogService(
     }
 
     /**
-     * Extracts the single game name that an apworld zip registers. Reads the
-     * archipelago.json manifest in-process; does not run Python. Throws
-     * BAD_REQUEST if the zip is missing a manifest or the `game` field.
+     * Extracts the single game name that an apworld zip registers.
+     *
+     * Fast path: reads the archipelago.json manifest in-process (no Python).
+     * Fallback: if the manifest is absent or its `game` field is blank, runs
+     * the same Python helper used for core games with the apworld placed in
+     * custom_worlds/, then diffs the result against the core game list.
      */
-    fun extractApWorldGame(apworldBytes: ByteArray): String {
+    suspend fun extractApWorldGame(apworldBytes: ByteArray, fileName: String): String {
+        val manifestGame = readManifestGame(apworldBytes)
+        if (manifestGame != null) return manifestGame
+
+        val coreGames = listCoreGames().map { it.name }.toSet()
+        return withContext(Dispatchers.IO) { runApWorldHelper(apworldBytes, fileName, coreGames) }
+    }
+
+    private fun readManifestGame(apworldBytes: ByteArray): String? {
         ByteArrayInputStream(apworldBytes).use { bis ->
             ZipInputStream(bis).use { zis ->
                 var entry = zis.nextEntry
                 while (entry != null) {
                     if (!entry.isDirectory && entry.name.endsWith("archipelago.json")) {
-                        val result = runCatching {
+                        return runCatching {
                             val manifest = jsonMapper.readValue(
                                 zis.readAllBytes(),
                                 ApWorldManifest::class.java,
                             )
-                            manifest.game.takeIf { it.isNotBlank() } ?: error("game field is blank")
-                        }
-                        return result.getOrElse {
-                            throw ResponseStatusException(
-                                HttpStatus.BAD_REQUEST,
-                                "APWorld manifest is missing a 'game' field",
-                            )
-                        }
+                            manifest.game?.takeIf { it.isNotBlank() }
+                        }.getOrNull()
                     }
                     entry = zis.nextEntry
                 }
             }
         }
-        throw ResponseStatusException(
-            HttpStatus.BAD_REQUEST,
-            "APWorld is missing an archipelago.json manifest — upload a newer apworld that declares its game.",
-        )
+        return null
+    }
+
+    private fun runApWorldHelper(apworldBytes: ByteArray, fileName: String, coreGames: Set<String>): String {
+        val archipelagoRoot = File(archipelagoScriptPath).absoluteFile.parentFile
+            ?: throw ResponseStatusException(
+                HttpStatus.INTERNAL_SERVER_ERROR,
+                "Cannot locate Archipelago root from script path $archipelagoScriptPath",
+            )
+        val scriptSrc = File(listGamesScriptPath).absoluteFile
+        if (!scriptSrc.isFile) {
+            throw ResponseStatusException(
+                HttpStatus.INTERNAL_SERVER_ERROR,
+                "list_games helper not found at ${scriptSrc.path}",
+            )
+        }
+
+        val workDir = Files.createTempDirectory("archipelago-apworld-games-").toFile()
+        try {
+            archipelagoRoot.copyRecursively(workDir, overwrite = true)
+            val customWorldsDir = workDir.resolve("custom_worlds").also { it.mkdirs() }
+            customWorldsDir.resolve(fileName).writeBytes(apworldBytes)
+            val scriptInWorkDir = workDir.resolve(scriptSrc.name)
+            scriptSrc.copyTo(scriptInWorkDir, overwrite = true)
+
+            val output = pythonScriptRunner.run(scriptInWorkDir.absolutePath, "core")
+            val allGames = parseCoreOutput(output).map { it.name }.toSet()
+            val apWorldGames = allGames - coreGames
+
+            return apWorldGames.singleOrNull()
+                ?: throw ResponseStatusException(
+                    HttpStatus.BAD_REQUEST,
+                    if (apWorldGames.isEmpty())
+                        "APWorld did not register any new game"
+                    else
+                        "APWorld registered multiple games: ${apWorldGames.sorted().joinToString()}",
+                )
+        } finally {
+            workDir.deleteRecursively()
+        }
     }
 
     private fun runCoreHelper(): List<GameInfo> {
@@ -146,7 +187,7 @@ internal data class CoreGamesPayload(
     val error: String? = null,
 )
 
-internal data class ApWorldManifest(val game: String)
+internal data class ApWorldManifest(val game: String? = null)
 
 /**
  * A game that can appear in a player's YAML `game:` field. `apworldFileName`

--- a/src/test/kotlin/com/github/derminator/archipelobby/generator/GameCatalogServiceTest.kt
+++ b/src/test/kotlin/com/github/derminator/archipelobby/generator/GameCatalogServiceTest.kt
@@ -216,7 +216,7 @@ private class SequentialFakePythonScriptRunner(private vararg val outputs: Strin
     override fun run(scriptPath: String, vararg args: String): String {
         val index = callIndex++
         return outputs.getOrElse(index) {
-            error("SequentialFakePythonScriptRunner called ${callIndex} times but only ${outputs.size} outputs were configured")
+            error("SequentialFakePythonScriptRunner called $callIndex times but only ${outputs.size} outputs were configured")
         }
     }
 }

--- a/src/test/kotlin/com/github/derminator/archipelobby/generator/GameCatalogServiceTest.kt
+++ b/src/test/kotlin/com/github/derminator/archipelobby/generator/GameCatalogServiceTest.kt
@@ -81,35 +81,83 @@ class GameCatalogServiceTest {
     }
 
     @Test
-    fun `extractApWorldGame reads game from archipelago manifest`(@TempDir tempDir: Path) {
+    fun `extractApWorldGame reads game from archipelago manifest`(@TempDir tempDir: Path) = runBlocking {
         val service = buildService(tempDir, stubbedOutput = "unused")
         val zipBytes = buildZip(mapOf("factorio/archipelago.json" to """{"game":"Factorio"}"""))
 
-        val game = service.extractApWorldGame(zipBytes)
+        val game = service.extractApWorldGame(zipBytes, "factorio.apworld")
 
         assertEquals("Factorio", game)
     }
 
     @Test
-    fun `extractApWorldGame throws when manifest is missing`(@TempDir tempDir: Path) {
-        val service = buildService(tempDir, stubbedOutput = "unused")
-        val zipBytes = buildZip(mapOf("something.py" to "print('hi')"))
+    fun `extractApWorldGame falls back to Python when manifest is missing`(@TempDir tempDir: Path) = runBlocking {
+        val runner = SequentialFakePythonScriptRunner(
+            """
+            <<<ARCHIPELOBBY_GAMES_JSON>>>
+            {"games":["Factorio"]}
+            <<<END>>>
+            """.trimIndent(),
+            """
+            <<<ARCHIPELOBBY_GAMES_JSON>>>
+            {"games":["Factorio","My Custom Game"]}
+            <<<END>>>
+            """.trimIndent(),
+        )
+        val service = buildService(tempDir, runner)
+        service.listCoreGames()
 
-        val exception = assertThrows<ResponseStatusException> {
-            service.extractApWorldGame(zipBytes)
-        }
-        assertTrue(exception.reason?.contains("archipelago.json") == true)
+        val zipBytes = buildZip(mapOf("something.py" to "print('hi')"))
+        val game = service.extractApWorldGame(zipBytes, "mycustomgame.apworld")
+
+        assertEquals("My Custom Game", game)
     }
 
     @Test
-    fun `extractApWorldGame throws when manifest has no game field`(@TempDir tempDir: Path) {
-        val service = buildService(tempDir, stubbedOutput = "unused")
-        val zipBytes = buildZip(mapOf("x/archipelago.json" to """{"compatible_version":7}"""))
+    fun `extractApWorldGame falls back to Python when game field is blank`(@TempDir tempDir: Path) = runBlocking {
+        val runner = SequentialFakePythonScriptRunner(
+            """
+            <<<ARCHIPELOBBY_GAMES_JSON>>>
+            {"games":["Factorio"]}
+            <<<END>>>
+            """.trimIndent(),
+            """
+            <<<ARCHIPELOBBY_GAMES_JSON>>>
+            {"games":["Factorio","My Custom Game"]}
+            <<<END>>>
+            """.trimIndent(),
+        )
+        val service = buildService(tempDir, runner)
+        service.listCoreGames()
 
+        val zipBytes = buildZip(mapOf("x/archipelago.json" to """{"compatible_version":7}"""))
+        val game = service.extractApWorldGame(zipBytes, "mycustomgame.apworld")
+
+        assertEquals("My Custom Game", game)
+    }
+
+    @Test
+    fun `extractApWorldGame throws when apworld registers no new game`(@TempDir tempDir: Path) = runBlocking {
+        val runner = SequentialFakePythonScriptRunner(
+            """
+            <<<ARCHIPELOBBY_GAMES_JSON>>>
+            {"games":["Factorio"]}
+            <<<END>>>
+            """.trimIndent(),
+            """
+            <<<ARCHIPELOBBY_GAMES_JSON>>>
+            {"games":["Factorio"]}
+            <<<END>>>
+            """.trimIndent(),
+        )
+        val service = buildService(tempDir, runner)
+        service.listCoreGames()
+
+        val zipBytes = buildZip(mapOf("something.py" to "print('hi')"))
         val exception = assertThrows<ResponseStatusException> {
-            service.extractApWorldGame(zipBytes)
+            service.extractApWorldGame(zipBytes, "broken.apworld")
         }
-        assertTrue(exception.reason?.contains("game") == true)
+        assertTrue(exception.reason?.contains("did not register") == true)
     }
 
     private fun buildService(
@@ -158,5 +206,17 @@ private class FakePythonScriptRunner(private val stubbedOutput: String) : Python
     override fun run(scriptPath: String, vararg args: String): String {
         invocationCount++
         return stubbedOutput
+    }
+}
+
+/** Returns successive canned outputs in order; throws if called more times than outputs provided. */
+private class SequentialFakePythonScriptRunner(private vararg val outputs: String) : PythonScriptRunner() {
+    private var callIndex = 0
+
+    override fun run(scriptPath: String, vararg args: String): String {
+        val index = callIndex++
+        return outputs.getOrElse(index) {
+            error("SequentialFakePythonScriptRunner called ${callIndex} times but only ${outputs.size} outputs were configured")
+        }
     }
 }

--- a/src/test/kotlin/com/github/derminator/archipelobby/generator/GameCatalogServiceTest.kt
+++ b/src/test/kotlin/com/github/derminator/archipelobby/generator/GameCatalogServiceTest.kt
@@ -162,7 +162,7 @@ class GameCatalogServiceTest {
 
     private fun buildService(
         tempDir: Path,
-        runner: FakePythonScriptRunner,
+        runner: PythonScriptRunner,
     ): GameCatalogService {
         val archipelagoRoot = tempDir.resolve("Archipelago").also { it.createDirectories() }
         archipelagoRoot.resolve("ModuleUpdate.py").writeText("def update(): pass")


### PR DESCRIPTION
## Summary

Closes #66

- `extractApWorldGame` now accepts a `fileName` parameter and is a `suspend fun`
- **Fast path unchanged**: if `archipelago.json` is present and has a non-blank `game` field, it's used as before (no Python invoked)
- **New fallback**: when the manifest is absent or `game` is missing/blank, the same Python helper used for core games runs with the APWorld placed in `custom_worlds/`; the result is diffed against the cached core game list to identify the newly registered game
- `ApWorldManifest.game` made nullable so missing fields deserialize cleanly instead of throwing

## Test plan

- [ ] Existing test `extractApWorldGame reads game from archipelago manifest` — still passes (fast path)
- [ ] `extractApWorldGame throws when manifest is missing` replaced by `falls back to Python when manifest is missing` — uses `SequentialFakePythonScriptRunner` to simulate core-games call followed by APWorld discovery call
- [ ] `extractApWorldGame throws when manifest has no game field` replaced by `falls back to Python when game field is blank`
- [ ] New test: APWorld that registers zero new games → throws BAD_REQUEST with "did not register" message
- [ ] All other existing tests unchanged

---
_Generated by [Claude Code](https://claude.ai/code/session_01WSRX336bod7tstt175eVoi)_