### PR TITLE
If the bot is disconnected from Discord, user checks don't work consistently

### DIFF
--- a/src/main/kotlin/com/github/derminator/archipelobby/discord/DiscordBotConfiguration.kt
+++ b/src/main/kotlin/com/github/derminator/archipelobby/discord/DiscordBotConfiguration.kt
@@ -14,7 +14,7 @@ import java.time.Duration
 class DiscordBotConfiguration {
 
     @Bean
-    fun discordGatewayProvider(@Value("\${DISCORD_BOT_TOKEN}") token: String): DiscordGatewayProvider =
+    fun discordGatewayProvider(@Value($$"${DISCORD_BOT_TOKEN}") token: String): DiscordGatewayProvider =
         DiscordGatewayProvider(token)
 
     @Bean
@@ -44,7 +44,7 @@ class DiscordGatewayProvider(
     @Synchronized
     fun getConnectedClient(): GatewayDiscordClient {
         val existing = gatewayDiscordClient
-        if (existing != null && existing.isConnected) {
+        if (existing != null && existing.isGatewayConnected()) {
             return existing
         }
 
@@ -54,7 +54,7 @@ class DiscordGatewayProvider(
         }
 
         val connected = login(token)
-        if (!connected.isConnected) {
+        if (!connected.isGatewayConnected()) {
             cleanupStaleClient(connected)
             throw IllegalStateException("Failed to connect to Discord: gateway client is disconnected")
         }
@@ -76,4 +76,9 @@ class DiscordGatewayProvider(
             logger.warn("Failed to logout disconnected Discord gateway client before reconnecting; continuing reconnect", ex)
         }
     }
+
+    private fun GatewayDiscordClient.isGatewayConnected(): Boolean =
+        getGatewayClient(0)
+            .map { it.isConnected().block() == true }
+            .orElse(false) == true
 }

--- a/src/main/kotlin/com/github/derminator/archipelobby/discord/DiscordBotConfiguration.kt
+++ b/src/main/kotlin/com/github/derminator/archipelobby/discord/DiscordBotConfiguration.kt
@@ -12,13 +12,35 @@ import org.springframework.context.annotation.Profile
 class DiscordBotConfiguration {
 
     @Bean
-    fun gatewayDiscordClient(@Value("\${DISCORD_BOT_TOKEN}") token: String): GatewayDiscordClient =
-        DiscordClientBuilder.create(token)
+    fun discordGatewayProvider(@Value("\${DISCORD_BOT_TOKEN}") token: String): DiscordGatewayProvider =
+        DiscordGatewayProvider(token)
+
+    @Bean
+    fun gatewayDiscordClient(discordGatewayProvider: DiscordGatewayProvider): GatewayDiscordClient =
+        discordGatewayProvider.getConnectedClient()
+
+    @Bean
+    fun discordService(discordGatewayProvider: DiscordGatewayProvider): DiscordService =
+        RealDiscordService(discordGatewayProvider)
+}
+
+class DiscordGatewayProvider(private val token: String) {
+    @Volatile
+    private var gatewayDiscordClient: GatewayDiscordClient? = null
+
+    @Synchronized
+    fun getConnectedClient(): GatewayDiscordClient {
+        val existing = gatewayDiscordClient
+        if (existing != null && existing.isConnected) {
+            return existing
+        }
+
+        existing?.logout()?.block()
+        val connected = DiscordClientBuilder.create(token)
             .build()
             .login()
             .block() ?: throw IllegalStateException("Failed to connect to Discord")
-
-    @Bean
-    fun discordService(gatewayDiscordClient: GatewayDiscordClient): DiscordService =
-        RealDiscordService(gatewayDiscordClient)
+        gatewayDiscordClient = connected
+        return connected
+    }
 }

--- a/src/main/kotlin/com/github/derminator/archipelobby/discord/DiscordBotConfiguration.kt
+++ b/src/main/kotlin/com/github/derminator/archipelobby/discord/DiscordBotConfiguration.kt
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Profile
+import java.time.Duration
 
 @Configuration
 @Profile("discord")
@@ -27,6 +28,7 @@ class DiscordBotConfiguration {
 
 class DiscordGatewayProvider(
     private val token: String,
+    private val logoutTimeout: Duration = Duration.ofSeconds(2),
     private val login: (String) -> GatewayDiscordClient = { loginToken ->
         DiscordClientBuilder.create(loginToken)
             .build()
@@ -48,15 +50,25 @@ class DiscordGatewayProvider(
 
         gatewayDiscordClient = null
         if (existing != null) {
-            try {
-                existing.logout().block()
-            } catch (ex: Exception) {
-                logger.warn("Failed to logout disconnected Discord gateway client before reconnecting; continuing reconnect", ex)
-            }
+            cleanupStaleClient(existing)
         }
 
         val connected = login(token)
         gatewayDiscordClient = connected
         return connected
+    }
+
+    private fun cleanupStaleClient(existing: GatewayDiscordClient) {
+        try {
+            existing.logout()
+                .timeout(logoutTimeout)
+                .doOnError { ex ->
+                    logger.warn("Failed to logout disconnected Discord gateway client before reconnecting; continuing reconnect", ex)
+                }
+                .onErrorComplete()
+                .subscribe()
+        } catch (ex: Exception) {
+            logger.warn("Failed to start logout for disconnected Discord gateway client before reconnecting; continuing reconnect", ex)
+        }
     }
 }

--- a/src/main/kotlin/com/github/derminator/archipelobby/discord/DiscordBotConfiguration.kt
+++ b/src/main/kotlin/com/github/derminator/archipelobby/discord/DiscordBotConfiguration.kt
@@ -54,6 +54,11 @@ class DiscordGatewayProvider(
         }
 
         val connected = login(token)
+        if (!connected.isConnected) {
+            cleanupStaleClient(connected)
+            throw IllegalStateException("Failed to connect to Discord: gateway client is disconnected")
+        }
+
         gatewayDiscordClient = connected
         return connected
     }

--- a/src/main/kotlin/com/github/derminator/archipelobby/discord/DiscordBotConfiguration.kt
+++ b/src/main/kotlin/com/github/derminator/archipelobby/discord/DiscordBotConfiguration.kt
@@ -2,6 +2,7 @@ package com.github.derminator.archipelobby.discord
 
 import discord4j.core.DiscordClientBuilder
 import discord4j.core.GatewayDiscordClient
+import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -24,7 +25,17 @@ class DiscordBotConfiguration {
         RealDiscordService(discordGatewayProvider)
 }
 
-class DiscordGatewayProvider(private val token: String) {
+class DiscordGatewayProvider(
+    private val token: String,
+    private val login: (String) -> GatewayDiscordClient = { loginToken ->
+        DiscordClientBuilder.create(loginToken)
+            .build()
+            .login()
+            .block() ?: throw IllegalStateException("Failed to connect to Discord")
+    }
+) {
+    private val logger = LoggerFactory.getLogger(DiscordGatewayProvider::class.java)
+
     @Volatile
     private var gatewayDiscordClient: GatewayDiscordClient? = null
 
@@ -35,11 +46,16 @@ class DiscordGatewayProvider(private val token: String) {
             return existing
         }
 
-        existing?.logout()?.block()
-        val connected = DiscordClientBuilder.create(token)
-            .build()
-            .login()
-            .block() ?: throw IllegalStateException("Failed to connect to Discord")
+        gatewayDiscordClient = null
+        if (existing != null) {
+            try {
+                existing.logout().block()
+            } catch (ex: Exception) {
+                logger.warn("Failed to logout disconnected Discord gateway client before reconnecting; continuing reconnect", ex)
+            }
+        }
+
+        val connected = login(token)
         gatewayDiscordClient = connected
         return connected
     }

--- a/src/main/kotlin/com/github/derminator/archipelobby/discord/DiscordBotConfiguration.kt
+++ b/src/main/kotlin/com/github/derminator/archipelobby/discord/DiscordBotConfiguration.kt
@@ -66,9 +66,9 @@ class DiscordGatewayProvider(
                     logger.warn("Failed to logout disconnected Discord gateway client before reconnecting; continuing reconnect", ex)
                 }
                 .onErrorComplete()
-                .subscribe()
+                .block()
         } catch (ex: Exception) {
-            logger.warn("Failed to start logout for disconnected Discord gateway client before reconnecting; continuing reconnect", ex)
+            logger.warn("Failed to logout disconnected Discord gateway client before reconnecting; continuing reconnect", ex)
         }
     }
 }

--- a/src/main/kotlin/com/github/derminator/archipelobby/discord/RealDiscordService.kt
+++ b/src/main/kotlin/com/github/derminator/archipelobby/discord/RealDiscordService.kt
@@ -1,7 +1,6 @@
 package com.github.derminator.archipelobby.discord
 
 import discord4j.common.util.Snowflake
-import discord4j.core.GatewayDiscordClient
 import discord4j.rest.util.Permission
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
@@ -11,12 +10,14 @@ import kotlinx.coroutines.reactor.awaitSingleOrNull
 import reactor.core.publisher.Mono
 
 class RealDiscordService(
-    private val gatewayDiscordClient: GatewayDiscordClient
+    private val gatewayProvider: DiscordGatewayProvider
 ) : DiscordService {
+
+    private fun client() = gatewayProvider.getConnectedClient()
 
     override suspend fun getGuildsForUser(userId: Long): Flow<GuildInfo> = flow {
         val userSnowflake = Snowflake.of(userId)
-        gatewayDiscordClient.guilds.asFlow().collect { guild ->
+        client().guilds.asFlow().collect { guild ->
             val member = guild.getMemberById(userSnowflake)
                 .onErrorResume { Mono.empty() }
                 .awaitSingleOrNull()
@@ -28,7 +29,7 @@ class RealDiscordService(
 
     override suspend fun getAdminGuildsForUser(userId: Long): Flow<GuildInfo> = flow {
         val userSnowflake = Snowflake.of(userId)
-        gatewayDiscordClient.guilds.asFlow().collect { guild ->
+        client().guilds.asFlow().collect { guild ->
             val member = guild.getMemberById(userSnowflake)
                 .onErrorResume { Mono.empty() }
                 .awaitSingleOrNull()
@@ -39,7 +40,7 @@ class RealDiscordService(
     }
 
     override suspend fun isMemberOfAnyGuild(userId: Long): Boolean =
-        gatewayDiscordClient.guilds
+        client().guilds
             .flatMap { guild ->
                 guild.getMemberById(Snowflake.of(userId))
                     .onErrorResume { Mono.empty() }
@@ -48,14 +49,14 @@ class RealDiscordService(
             .awaitSingle()
 
     override suspend fun isMemberOfGuild(userId: Long, guildId: Long): Boolean =
-        gatewayDiscordClient.getGuildById(Snowflake.of(guildId))
+        client().getGuildById(Snowflake.of(guildId))
             .flatMap { it.getMemberById(Snowflake.of(userId)) }
             .map { true }
             .onErrorReturn(false)
             .awaitSingle()
 
     override suspend fun isAdminOfGuild(userId: Long, guildId: Long): Boolean =
-        gatewayDiscordClient.getGuildById(Snowflake.of(guildId))
+        client().getGuildById(Snowflake.of(guildId))
             .flatMap { it.getMemberById(Snowflake.of(userId)) }
             .flatMap { it.basePermissions }
             .map { it.contains(Permission.ADMINISTRATOR) }
@@ -63,12 +64,12 @@ class RealDiscordService(
             .awaitSingle()
 
     override suspend fun getUserInfo(userId: Long): UserInfo =
-        gatewayDiscordClient.getUserById(Snowflake.of(userId))
+        client().getUserById(Snowflake.of(userId))
             .map { UserInfo(it.id.asLong(), it.username) }
             .awaitSingle()
 
     override suspend fun getGuildInfo(guildId: Long): GuildInfo =
-        gatewayDiscordClient.getGuildById(Snowflake.of(guildId))
+        client().getGuildById(Snowflake.of(guildId))
             .map { GuildInfo(it.id.asLong(), it.name) }
             .awaitSingle()
 }

--- a/src/test/kotlin/com/github/derminator/archipelobby/discord/DiscordGatewayProviderTest.kt
+++ b/src/test/kotlin/com/github/derminator/archipelobby/discord/DiscordGatewayProviderTest.kt
@@ -1,0 +1,45 @@
+package com.github.derminator.archipelobby.discord
+
+import discord4j.core.GatewayDiscordClient
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.whenever
+import reactor.core.publisher.Mono
+import kotlin.test.assertEquals
+
+class DiscordGatewayProviderTest {
+
+    @Test
+    fun `returns cached client while connected`() {
+        val connectedClient = mock(GatewayDiscordClient::class.java)
+        whenever(connectedClient.isConnected).thenReturn(true)
+
+        var loginCount = 0
+        val provider = DiscordGatewayProvider("token") {
+            loginCount++
+            connectedClient
+        }
+
+        assertSame(connectedClient, provider.getConnectedClient())
+        assertSame(connectedClient, provider.getConnectedClient())
+        assertEquals(1, loginCount)
+    }
+
+    @Test
+    fun `reconnects when cached client is disconnected even if logout fails`() {
+        val disconnectedClient = mock(GatewayDiscordClient::class.java)
+        whenever(disconnectedClient.isConnected).thenReturn(false)
+        whenever(disconnectedClient.logout()).thenReturn(Mono.error(RuntimeException("gateway already broken")))
+
+        val reconnectedClient = mock(GatewayDiscordClient::class.java)
+        whenever(reconnectedClient.isConnected).thenReturn(true)
+
+        val logins = ArrayDeque(listOf(disconnectedClient, reconnectedClient))
+        val provider = DiscordGatewayProvider("token") { logins.removeFirst() }
+
+        assertSame(disconnectedClient, provider.getConnectedClient())
+        assertSame(reconnectedClient, provider.getConnectedClient())
+        assertEquals(0, logins.size)
+    }
+}

--- a/src/test/kotlin/com/github/derminator/archipelobby/discord/DiscordGatewayProviderTest.kt
+++ b/src/test/kotlin/com/github/derminator/archipelobby/discord/DiscordGatewayProviderTest.kt
@@ -46,7 +46,7 @@ class DiscordGatewayProviderTest {
     }
 
     @Test
-    fun `reconnect is not blocked by non completing logout`() {
+    fun `reconnect waits only until logout timeout for non completing logout`() {
         val disconnectedClient = mock(GatewayDiscordClient::class.java)
         whenever(disconnectedClient.isConnected).thenReturn(false)
         whenever(disconnectedClient.logout()).thenReturn(Mono.never())
@@ -55,7 +55,8 @@ class DiscordGatewayProviderTest {
         whenever(reconnectedClient.isConnected).thenReturn(true)
 
         val logins = ArrayDeque(listOf(disconnectedClient, reconnectedClient))
-        val provider = DiscordGatewayProvider("token", Duration.ofMillis(50)) { logins.removeFirst() }
+        val logoutTimeout = Duration.ofMillis(50)
+        val provider = DiscordGatewayProvider("token", logoutTimeout) { logins.removeFirst() }
 
         assertSame(disconnectedClient, provider.getConnectedClient())
 
@@ -63,7 +64,8 @@ class DiscordGatewayProviderTest {
         assertSame(reconnectedClient, provider.getConnectedClient())
         val elapsed = Duration.ofNanos(System.nanoTime() - startedAt)
 
-        assertTrue(elapsed < Duration.ofSeconds(1), "Reconnect should not wait for a non-completing logout")
+        assertTrue(elapsed >= logoutTimeout, "Reconnect should give stale logout a bounded chance to complete")
+        assertTrue(elapsed < Duration.ofSeconds(1), "Reconnect should not wait indefinitely for a non-completing logout")
         assertEquals(0, logins.size)
     }
 }

--- a/src/test/kotlin/com/github/derminator/archipelobby/discord/DiscordGatewayProviderTest.kt
+++ b/src/test/kotlin/com/github/derminator/archipelobby/discord/DiscordGatewayProviderTest.kt
@@ -1,13 +1,15 @@
 package com.github.derminator.archipelobby.discord
 
 import discord4j.core.GatewayDiscordClient
+import discord4j.gateway.GatewayClient
 import org.junit.jupiter.api.Assertions.assertSame
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.mockito.Mockito.mock
-import org.mockito.kotlin.whenever
+import org.mockito.Mockito.`when` as whenever
 import reactor.core.publisher.Mono
 import java.time.Duration
+import java.util.Optional
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
@@ -15,8 +17,7 @@ class DiscordGatewayProviderTest {
 
     @Test
     fun `returns cached client while connected`() {
-        val connectedClient = mock(GatewayDiscordClient::class.java)
-        whenever(connectedClient.isConnected).thenReturn(true)
+        val connectedClient = gatewayClient(true)
 
         var loginCount = 0
         val provider = DiscordGatewayProvider("token") {
@@ -31,12 +32,10 @@ class DiscordGatewayProviderTest {
 
     @Test
     fun `does not cache or return disconnected client from login`() {
-        val disconnectedClient = mock(GatewayDiscordClient::class.java)
-        whenever(disconnectedClient.isConnected).thenReturn(false)
+        val disconnectedClient = gatewayClient(false)
         whenever(disconnectedClient.logout()).thenReturn(Mono.empty())
 
-        val connectedClient = mock(GatewayDiscordClient::class.java)
-        whenever(connectedClient.isConnected).thenReturn(true)
+        val connectedClient = gatewayClient(true)
 
         val logins = ArrayDeque(listOf(disconnectedClient, connectedClient))
         val provider = DiscordGatewayProvider("token") { logins.removeFirst() }
@@ -48,12 +47,10 @@ class DiscordGatewayProviderTest {
 
     @Test
     fun `reconnects when cached client is disconnected even if logout fails`() {
-        val disconnectedClient = mock(GatewayDiscordClient::class.java)
-        whenever(disconnectedClient.isConnected).thenReturn(true, false)
+        val disconnectedClient = gatewayClient(true, false)
         whenever(disconnectedClient.logout()).thenReturn(Mono.error(RuntimeException("gateway already broken")))
 
-        val reconnectedClient = mock(GatewayDiscordClient::class.java)
-        whenever(reconnectedClient.isConnected).thenReturn(true)
+        val reconnectedClient = gatewayClient(true)
 
         val logins = ArrayDeque(listOf(disconnectedClient, reconnectedClient))
         val provider = DiscordGatewayProvider("token") { logins.removeFirst() }
@@ -65,12 +62,10 @@ class DiscordGatewayProviderTest {
 
     @Test
     fun `reconnect waits only until logout timeout for non completing logout`() {
-        val disconnectedClient = mock(GatewayDiscordClient::class.java)
-        whenever(disconnectedClient.isConnected).thenReturn(true, false)
+        val disconnectedClient = gatewayClient(true, false)
         whenever(disconnectedClient.logout()).thenReturn(Mono.never())
 
-        val reconnectedClient = mock(GatewayDiscordClient::class.java)
-        whenever(reconnectedClient.isConnected).thenReturn(true)
+        val reconnectedClient = gatewayClient(true)
 
         val logins = ArrayDeque(listOf(disconnectedClient, reconnectedClient))
         val logoutTimeout = Duration.ofMillis(50)
@@ -85,5 +80,16 @@ class DiscordGatewayProviderTest {
         assertTrue(elapsed >= logoutTimeout, "Reconnect should give stale logout a bounded chance to complete")
         assertTrue(elapsed < Duration.ofSeconds(1), "Reconnect should not wait indefinitely for a non-completing logout")
         assertEquals(0, logins.size)
+    }
+
+    private fun gatewayClient(vararg connectedStates: Boolean): GatewayDiscordClient {
+        val gatewayDiscordClient = mock(GatewayDiscordClient::class.java)
+        val gatewayClient = mock(GatewayClient::class.java)
+        whenever(gatewayClient.isConnected()).thenReturn(
+            Mono.just(connectedStates.first()),
+            *connectedStates.drop(1).map { Mono.just(it) }.toTypedArray()
+        )
+        whenever(gatewayDiscordClient.getGatewayClient(0)).thenReturn(Optional.of(gatewayClient))
+        return gatewayDiscordClient
     }
 }

--- a/src/test/kotlin/com/github/derminator/archipelobby/discord/DiscordGatewayProviderTest.kt
+++ b/src/test/kotlin/com/github/derminator/archipelobby/discord/DiscordGatewayProviderTest.kt
@@ -6,7 +6,9 @@ import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock
 import org.mockito.kotlin.whenever
 import reactor.core.publisher.Mono
+import java.time.Duration
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class DiscordGatewayProviderTest {
 
@@ -40,6 +42,28 @@ class DiscordGatewayProviderTest {
 
         assertSame(disconnectedClient, provider.getConnectedClient())
         assertSame(reconnectedClient, provider.getConnectedClient())
+        assertEquals(0, logins.size)
+    }
+
+    @Test
+    fun `reconnect is not blocked by non completing logout`() {
+        val disconnectedClient = mock(GatewayDiscordClient::class.java)
+        whenever(disconnectedClient.isConnected).thenReturn(false)
+        whenever(disconnectedClient.logout()).thenReturn(Mono.never())
+
+        val reconnectedClient = mock(GatewayDiscordClient::class.java)
+        whenever(reconnectedClient.isConnected).thenReturn(true)
+
+        val logins = ArrayDeque(listOf(disconnectedClient, reconnectedClient))
+        val provider = DiscordGatewayProvider("token", Duration.ofMillis(50)) { logins.removeFirst() }
+
+        assertSame(disconnectedClient, provider.getConnectedClient())
+
+        val startedAt = System.nanoTime()
+        assertSame(reconnectedClient, provider.getConnectedClient())
+        val elapsed = Duration.ofNanos(System.nanoTime() - startedAt)
+
+        assertTrue(elapsed < Duration.ofSeconds(1), "Reconnect should not wait for a non-completing logout")
         assertEquals(0, logins.size)
     }
 }

--- a/src/test/kotlin/com/github/derminator/archipelobby/discord/DiscordGatewayProviderTest.kt
+++ b/src/test/kotlin/com/github/derminator/archipelobby/discord/DiscordGatewayProviderTest.kt
@@ -3,6 +3,7 @@ package com.github.derminator.archipelobby.discord
 import discord4j.core.GatewayDiscordClient
 import org.junit.jupiter.api.Assertions.assertSame
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.mockito.Mockito.mock
 import org.mockito.kotlin.whenever
 import reactor.core.publisher.Mono
@@ -29,9 +30,26 @@ class DiscordGatewayProviderTest {
     }
 
     @Test
-    fun `reconnects when cached client is disconnected even if logout fails`() {
+    fun `does not cache or return disconnected client from login`() {
         val disconnectedClient = mock(GatewayDiscordClient::class.java)
         whenever(disconnectedClient.isConnected).thenReturn(false)
+        whenever(disconnectedClient.logout()).thenReturn(Mono.empty())
+
+        val connectedClient = mock(GatewayDiscordClient::class.java)
+        whenever(connectedClient.isConnected).thenReturn(true)
+
+        val logins = ArrayDeque(listOf(disconnectedClient, connectedClient))
+        val provider = DiscordGatewayProvider("token") { logins.removeFirst() }
+
+        assertThrows<IllegalStateException> { provider.getConnectedClient() }
+        assertSame(connectedClient, provider.getConnectedClient())
+        assertEquals(0, logins.size)
+    }
+
+    @Test
+    fun `reconnects when cached client is disconnected even if logout fails`() {
+        val disconnectedClient = mock(GatewayDiscordClient::class.java)
+        whenever(disconnectedClient.isConnected).thenReturn(true, false)
         whenever(disconnectedClient.logout()).thenReturn(Mono.error(RuntimeException("gateway already broken")))
 
         val reconnectedClient = mock(GatewayDiscordClient::class.java)
@@ -48,7 +66,7 @@ class DiscordGatewayProviderTest {
     @Test
     fun `reconnect waits only until logout timeout for non completing logout`() {
         val disconnectedClient = mock(GatewayDiscordClient::class.java)
-        whenever(disconnectedClient.isConnected).thenReturn(false)
+        whenever(disconnectedClient.isConnected).thenReturn(true, false)
         whenever(disconnectedClient.logout()).thenReturn(Mono.never())
 
         val reconnectedClient = mock(GatewayDiscordClient::class.java)


### PR DESCRIPTION
Closes #41

Final automated review:
The change addresses the issue by centralizing Discord gateway access behind `DiscordGatewayProvider`, checking `isConnected` before each service operation, reconnecting when the cached client is disconnected, and refusing to return/cache a disconnected login result. The stale-client cleanup is bounded and tolerant of logout failures, and the new tests cover the main provider behaviors.

I did not find any blocking correctness, security, compatibility, or test-coverage issues in the diff. This branch looks ready to become a pull request.

_Implemented and reviewed by ai-harness._