### PR TITLE
Rooms fail to display in the Docker image with an error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates python3 python3-venv python3-pip python3-dev git cmake build-essential && \
     rm -rf /var/lib/apt/lists/*
 
-# Pre-create an empty venv so ModuleUpdate.py's pip install lands in a
-# writable, PEP 668-clean location. Archipelago deps install on first run.
+# Pre-create a venv so Archipelago's pinned dependencies install in a
+# writable, PEP 668-clean location.
 RUN python3 -m venv /app/.venv && /app/.venv/bin/pip install --upgrade pip
 
 ENV PIP_NO_CACHE_DIR=1
@@ -27,11 +27,14 @@ COPY --from=build /app/build/libs/*.jar app.jar
 COPY ./Archipelago ./Archipelago
 COPY ./python ./python
 
+# Install the exact Archipelago dependency set while building the image. This
+# prevents ModuleUpdate from needing to prompt while a room is being displayed.
+RUN /app/.venv/bin/python /app/Archipelago/ModuleUpdate.py --yes
+
 RUN chown -R appuser:appuser /app
 USER appuser
 
-# Point the runner at the pre-created venv's python so ModuleUpdate.py's
-# pip installs land in /app/.venv (writable by appuser, PEP 668 clean).
+# Point the runner at the pre-created venv's python for Archipelago scripts.
 ENV ARCHIPELOBBY_PYTHON_EXECUTABLE=/app/.venv/bin/python
 
 EXPOSE 8080 38281-38380

--- a/README.md
+++ b/README.md
@@ -137,6 +137,9 @@ application restart.
 
 The application will be available at `http://localhost:8080`
 
+The Docker build installs Archipelago's pinned Python dependencies into the
+image. This avoids an interactive dependency prompt when opening a room.
+
 ## Usage
 
 1. **Login**: Navigate to the application and login with Discord

--- a/python/list_games.py
+++ b/python/list_games.py
@@ -23,10 +23,10 @@ def _emit(payload):
 
 
 def _list_core_games():
-    if "--yes" not in sys.argv:
-        sys.argv.append("--yes")
     import ModuleUpdate
-    ModuleUpdate.update()
+    # ModuleUpdate only reads command-line flags when run as a script; pass
+    # yes directly because this helper imports it in a non-interactive process.
+    ModuleUpdate.update(yes=True)
 
     import worlds  # noqa: F401 (import side effect: populates AutoWorldRegister)
     from worlds.AutoWorld import AutoWorldRegister

--- a/python/test_list_games.py
+++ b/python/test_list_games.py
@@ -1,0 +1,47 @@
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import list_games
+
+
+class ListGamesTest(unittest.TestCase):
+    def test_core_game_listing_updates_requirements_noninteractively(self):
+        update_calls = []
+        module_update = types.ModuleType("ModuleUpdate")
+        module_update.update = lambda **kwargs: update_calls.append(kwargs)
+
+        worlds = types.ModuleType("worlds")
+        auto_world = types.ModuleType("worlds.AutoWorld")
+        auto_world.AutoWorldRegister = types.SimpleNamespace(
+            world_types={"Factorio": object(), "A Link to the Past": object()},
+        )
+
+        with patch.dict(
+            sys.modules,
+            {
+                "ModuleUpdate": module_update,
+                "worlds": worlds,
+                "worlds.AutoWorld": auto_world,
+            },
+        ):
+            self.assertEqual(
+                list_games._list_core_games(),
+                ["A Link to the Past", "Factorio"],
+            )
+
+        self.assertEqual(update_calls, [{"yes": True}])
+
+    def test_docker_image_installs_archipelago_requirements(self):
+        dockerfile = Path(__file__).parent.parent / "Dockerfile"
+
+        self.assertIn(
+            "/app/.venv/bin/python /app/Archipelago/ModuleUpdate.py --yes",
+            dockerfile.read_text(),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #76

## Summary

- Pre-installs Archipelago's pinned Python dependencies into the Docker image during build, preventing runtime dependency prompts when rooms are displayed.
- Runs `ModuleUpdate` non-interactively when listing core games by passing `yes=True` directly, avoiding EOF failures from interactive input.
- Documents the Docker dependency-install behavior.
- Adds coverage for non-interactive game enumeration and the Docker build dependency-install command.

_Implemented by ai-harness._