### PR TITLE
Worlds with excessive items cannot be added

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ image. This avoids an interactive dependency prompt when opening a room.
 
 1. **Login**: Navigate to the application and login with Discord
 2. **Create Room**: Select a Discord guild you administer and create a new room
-3. **Upload YAML**: In a room, upload Archipelago YAML files with entry names
+3. **Upload YAML**: In a room, upload Archipelago YAML files with entry names. World-generation warnings emitted while validating a YAML do not prevent its upload.
 4. **Upload APWorlds**: Upload any custom `.apworld` files needed by the room's games
 5. **Manage Entries**: Rename, download, or delete individual entries
 6. **Generate**: Generate a multiworld from the room's YAMLs, producing patch files, a generated game bundle, and a

--- a/src/main/kotlin/com/github/derminator/archipelobby/generator/RealArchipelagoGeneratorService.kt
+++ b/src/main/kotlin/com/github/derminator/archipelobby/generator/RealArchipelagoGeneratorService.kt
@@ -96,7 +96,7 @@ class RealArchipelagoGeneratorService(
                 val archipelagoDir = File(scriptPath).absoluteFile.parent
                 val args = (listOf(archipelagoDir, yamlFile.absolutePath) + apWorldPaths).toTypedArray()
                 val output = pythonScriptRunner.run(File(locationCountScriptPath).absoluteFile.path, *args)
-                output.trim().toIntOrNull()
+                parseLocationCount(output)
                     ?: throw ResponseStatusException(
                         HttpStatus.INTERNAL_SERVER_ERROR,
                         "Location count script produced unexpected output: ${output.trim()}",
@@ -106,3 +106,13 @@ class RealArchipelagoGeneratorService(
             }
         }
 }
+
+/**
+ * The Python runner merges stderr into stdout, so world-generation warnings can
+ * precede the count. The location-count script always prints its result last.
+ */
+internal fun parseLocationCount(output: String): Int? =
+    output.lineSequence()
+        .map(String::trim)
+        .lastOrNull { it.isNotEmpty() }
+        ?.toIntOrNull()

--- a/src/test/kotlin/com/github/derminator/archipelobby/generator/RealArchipelagoGeneratorServiceTest.kt
+++ b/src/test/kotlin/com/github/derminator/archipelobby/generator/RealArchipelagoGeneratorServiceTest.kt
@@ -1,0 +1,23 @@
+package com.github.derminator.archipelobby.generator
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class RealArchipelagoGeneratorServiceTest {
+
+    @Test
+    fun `parses location count after world generation warning`() {
+        val output = """
+            WARNING:root:Manual_ResidentEvil4_VincentsSin has more items than locations. 400 non-progression items will be removed at random.
+            760
+        """.trimIndent()
+
+        assertEquals(760, parseLocationCount(output))
+    }
+
+    @Test
+    fun `rejects output whose final line is not a location count`() {
+        assertNull(parseLocationCount("760\nunexpected output"))
+    }
+}


### PR DESCRIPTION
Closes #79

## Summary

- Allow YAML validation to succeed when Archipelago emits world-generation warnings before the location count.
- Parse the final non-empty line of script output as the location count, since stderr is merged into stdout.
- Document that validation warnings do not block YAML uploads.

## Tests

- Added coverage for parsing a location count after a warning.
- Added coverage for rejecting output whose final line is not a valid count.

_Implemented by ai-harness._