### PR TITLE
fix: override vulnerable transitive dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,17 @@ repositories {
     mavenCentral()
 }
 
+// Spring Boot's dependency-management plugin uses this property for its Jackson 2 BOM.
+extra["jackson-2-bom.version"] = "2.21.5"
+
 dependencies {
+    constraints {
+        // commons-io is transitive (via the Discord4J dependency graph).
+        implementation("commons-io:commons-io:2.22.0") {
+            because("Override vulnerable transitive Commons IO versions")
+        }
+    }
+
     implementation("org.springframework.boot:spring-boot-starter-actuator")
     implementation("org.springframework.boot:spring-boot-starter-data-r2dbc")
     implementation("org.springframework.boot:spring-boot-starter-r2dbc")


### PR DESCRIPTION
## Summary
- Override Spring Boot's Jackson 2 BOM from 2.21.4 to 2.21.5.
- Constrain transitive `commons-io` from 2.6 to 2.22.0.

Both alerts are transitive: Jackson 2 is pulled through the Discord4J/Spring dependency graph, and Commons IO is pulled through Discord4J voice dependencies (`lava-common`).

## Verification
- `./gradlew dependencyInsight --dependency jackson-databind --configuration runtimeClasspath` resolves `com.fasterxml.jackson.core:jackson-databind:2.21.5`.
- `./gradlew dependencyInsight --dependency commons-io --configuration runtimeClasspath` resolves `commons-io:commons-io:2.22.0`.
- `./gradlew test` reaches compilation but is blocked by the local Windows environment because the build invokes `python3`, which is not installed/available as a command.

## Scope
Only `build.gradle.kts` is included in this commit. Existing unrelated working-tree changes were left untouched.
