### PR TITLE
feat: use UUIDs for new room URLs

### DIFF
--- a/src/main/kotlin/com/github/derminator/archipelobby/controllers/RoomController.kt
+++ b/src/main/kotlin/com/github/derminator/archipelobby/controllers/RoomController.kt
@@ -71,7 +71,7 @@ class RoomController(
                 ?: throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Required form parameter 'name' is not present")
 
             val room = roomService.createRoom(guildId, name, userId)
-            "redirect:/rooms/${room.id}"
+            "redirect:/rooms/${room.urlId}"
         } catch (e: ResponseStatusException) {
             if (e.statusCode == HttpStatus.BAD_REQUEST || e.statusCode == HttpStatus.CONFLICT) {
                 loadRoomsModel(userId, model)
@@ -83,19 +83,20 @@ class RoomController(
 
     @GetMapping("/{roomId}")
     fun getRoom(
-        @PathVariable roomId: Long,
+        @PathVariable roomId: String,
         principal: Principal?,
         exchange: ServerWebExchange,
         model: Model
     ): Mono<String> = mono {
+        val internalRoomId = roomService.resolveRoomUrlId(roomId)
         if (principal == null || principal is AnonymousAuthenticationToken) {
-            val preview = roomService.getRoomForPreview(roomId)
+            val preview = roomService.getRoomForPreview(internalRoomId)
             model.addAttribute("preview", preview)
-            model.addAttribute("pun", Puns.forRoom(roomId))
+            model.addAttribute("pun", Puns.forRoom(internalRoomId))
             return@mono "room-preview"
         }
         val userId = principal.asDiscordPrincipal.userId
-        loadRoomModel(roomId, userId, model, exchange)
+        loadRoomModel(internalRoomId, userId, model, exchange, roomId)
         "room"
     }
 
@@ -108,13 +109,14 @@ class RoomController(
 
     @PostMapping("/{roomId}/entries")
     fun addEntry(
-        @PathVariable roomId: Long,
+        @PathVariable roomId: String,
         principal: Principal,
         @ModelAttribute form: AddEntryForm,
         exchange: ServerWebExchange,
         model: Model,
     ): Mono<String> = mono {
         val userId = principal.asDiscordPrincipal.userId
+        val internalRoomId = roomService.resolveRoomUrlId(roomId)
         try {
             val yamlFile = form.yamlFile
 
@@ -152,7 +154,7 @@ class RoomController(
 
             try {
                 roomService.addEntry(
-                    roomId = roomId,
+                    roomId = internalRoomId,
                     userId = userId,
                     entryName = entryYaml.name,
                     game = entryYaml.game,
@@ -167,7 +169,7 @@ class RoomController(
             "redirect:/rooms/$roomId"
         } catch (e: ResponseStatusException) {
             if (e.statusCode == HttpStatus.BAD_REQUEST || e.statusCode == HttpStatus.CONFLICT) {
-                loadRoomModel(roomId, userId, model, exchange)
+                loadRoomModel(internalRoomId, userId, model, exchange, roomId)
                 model.addAttribute("errorMessage", e.reason ?: "An error occurred")
                 "room"
             } else throw e
@@ -176,23 +178,25 @@ class RoomController(
 
     @PostMapping("/{roomId}/entries/{entryId}/delete")
     fun deleteEntry(
-        @PathVariable roomId: Long,
+        @PathVariable roomId: String,
         @PathVariable entryId: Long,
         principal: Principal
     ): Mono<String> = mono {
+        val internalRoomId = roomService.resolveRoomUrlId(roomId)
         val userId = principal.asDiscordPrincipal.userId
-        roomService.deleteEntry(entryId, userId)
+        roomService.deleteEntry(entryId, internalRoomId, userId)
         "redirect:/rooms/$roomId"
     }
 
     @GetMapping("/{roomId}/entries/{entryId}/download")
     fun downloadEntry(
-        @PathVariable roomId: Long,
+        @PathVariable roomId: String,
         @PathVariable entryId: Long,
         principal: Principal,
     ): Mono<ResponseEntity<ByteArray>> = mono {
+        val internalRoomId = roomService.resolveRoomUrlId(roomId)
         val userId = principal.asDiscordPrincipal.userId
-        val entry = roomService.getEntryForDownload(entryId, roomId, userId)
+        val entry = roomService.getEntryForDownload(entryId, internalRoomId, userId)
 
         val fileExists = uploadsService.fileExists(entry.yamlFilePath)
         if (!fileExists) {
@@ -210,12 +214,13 @@ class RoomController(
 
     @GetMapping("/{roomId}/patches/{patchId}/download")
     fun downloadPatch(
-        @PathVariable roomId: Long,
+        @PathVariable roomId: String,
         @PathVariable patchId: Long,
         principal: Principal,
     ): Mono<ResponseEntity<ByteArray>> = mono {
+        val internalRoomId = roomService.resolveRoomUrlId(roomId)
         val userId = principal.asDiscordPrincipal.userId
-        val patch = roomService.getPatchForDownload(patchId, roomId, userId)
+        val patch = roomService.getPatchForDownload(patchId, internalRoomId, userId)
 
         if (!uploadsService.fileExists(patch.filePath)) {
             throw ResponseStatusException(HttpStatus.NOT_FOUND, "Patch file not found")
@@ -231,12 +236,13 @@ class RoomController(
 
     @GetMapping("/{roomId}/apworlds/{apworldId}/download")
     fun downloadApWorld(
-        @PathVariable roomId: Long,
+        @PathVariable roomId: String,
         @PathVariable apworldId: Long,
         principal: Principal,
     ): Mono<ResponseEntity<ByteArray>> = mono {
+        val internalRoomId = roomService.resolveRoomUrlId(roomId)
         val userId = principal.asDiscordPrincipal.userId
-        val apWorld = roomService.getApWorldForDownload(apworldId, roomId, userId)
+        val apWorld = roomService.getApWorldForDownload(apworldId, internalRoomId, userId)
 
         val fileExists = uploadsService.fileExists(apWorld.filePath)
         if (!fileExists) {
@@ -253,25 +259,27 @@ class RoomController(
 
     @PostMapping("/{roomId}/apworlds/{apworldId}/delete")
     fun deleteApWorld(
-        @PathVariable roomId: Long,
+        @PathVariable roomId: String,
         @PathVariable apworldId: Long,
         principal: Principal
     ): Mono<String> = mono {
+        val internalRoomId = roomService.resolveRoomUrlId(roomId)
         val userId = principal.asDiscordPrincipal.userId
-        roomService.deleteApWorld(apworldId, userId)
+        roomService.deleteApWorld(apworldId, internalRoomId, userId)
         "redirect:/rooms/$roomId"
     }
 
     @GetMapping("/{roomId}/download")
     fun downloadAll(
-        @PathVariable roomId: Long,
+        @PathVariable roomId: String,
         principal: Principal
     ): Mono<ResponseEntity<ByteArray>> = mono {
+        val internalRoomId = roomService.resolveRoomUrlId(roomId)
         val userId = principal.asDiscordPrincipal.userId
-        val roomWithEntries = roomService.getRoom(roomId, userId)
+        val roomWithEntries = roomService.getRoom(internalRoomId, userId)
 
         val entries = roomWithEntries.entries.toList()
-        val apWorlds = roomService.getApWorldsForRoom(roomId, userId).toList()
+        val apWorlds = roomService.getApWorldsForRoom(internalRoomId, userId).toList()
 
         val zipBytes = withContext(Dispatchers.IO) {
             val byteArrayOutputStream = ByteArrayOutputStream()
@@ -307,17 +315,18 @@ class RoomController(
 
     @PostMapping("/{roomId}/generate")
     fun generateGame(
-        @PathVariable roomId: Long,
+        @PathVariable roomId: String,
         principal: Principal,
     ): Mono<String> = mono {
+        val internalRoomId = roomService.resolveRoomUrlId(roomId)
         val userId = principal.asDiscordPrincipal.userId
-        roomService.generateGame(roomId, userId)
+        roomService.generateGame(internalRoomId, userId)
         "redirect:/rooms/$roomId"
     }
 
     @PostMapping("/{roomId}/upload-game")
     fun uploadGame(
-        @PathVariable roomId: Long,
+        @PathVariable roomId: String,
         principal: Principal,
         @ModelAttribute form: UploadGameForm,
         exchange: ServerWebExchange,
@@ -334,14 +343,14 @@ class RoomController(
                 )
             }
             val fileBytes = readFilePart(filePart)
-            roomService.uploadGame(roomId, userId, fileBytes, filename)
+            roomService.uploadGame(roomService.resolveRoomUrlId(roomId), userId, fileBytes, filename)
             "redirect:/rooms/$roomId"
         } catch (e: ResponseStatusException) {
             if (e.statusCode == HttpStatus.BAD_REQUEST
                 || e.statusCode == HttpStatus.CONFLICT
                 || e.statusCode == HttpStatus.UNPROCESSABLE_CONTENT
             ) {
-                loadRoomModel(roomId, userId, model, exchange)
+                loadRoomModel(roomService.resolveRoomUrlId(roomId), userId, model, exchange, roomId)
                 model.addAttribute("errorMessage", e.reason ?: "An error occurred")
                 "room"
             } else throw e
@@ -350,25 +359,26 @@ class RoomController(
 
     @PostMapping("/{roomId}/generated-game/delete")
     fun deleteGeneratedGame(
-        @PathVariable roomId: Long,
+        @PathVariable roomId: String,
         principal: Principal,
     ): Mono<String> = mono {
         val userId = principal.asDiscordPrincipal.userId
         // Stop the server first (outside the delete's transaction) so its up-to-10s
         // shutdown wait doesn't hold the DB connection, and a late autosave can't
         // resurrect the save state deleteGeneratedGame is about to clear.
-        roomService.stopServer(roomId, userId)
-        roomService.deleteGeneratedGame(roomId, userId)
+        val internalRoomId = roomService.resolveRoomUrlId(roomId)
+        roomService.stopServer(internalRoomId, userId)
+        roomService.deleteGeneratedGame(internalRoomId, userId)
         "redirect:/rooms/$roomId"
     }
 
     @GetMapping("/{roomId}/generated-game/download")
     fun downloadGeneratedGame(
-        @PathVariable roomId: Long,
+        @PathVariable roomId: String,
         principal: Principal,
     ): Mono<ResponseEntity<ByteArray>> = mono {
         val userId = principal.asDiscordPrincipal.userId
-        val room = roomService.getGeneratedGameForDownload(roomId, userId)
+        val room = roomService.getGeneratedGameForDownload(roomService.resolveRoomUrlId(roomId), userId)
         val filePath = room.generatedGameFilePath
 
         if (filePath == null || !uploadsService.fileExists(filePath)) {
@@ -386,11 +396,11 @@ class RoomController(
 
     @GetMapping("/{roomId}/walkthrough/download")
     fun downloadWalkthrough(
-        @PathVariable roomId: Long,
+        @PathVariable roomId: String,
         principal: Principal,
     ): Mono<ResponseEntity<ByteArray>> = mono {
         val userId = principal.asDiscordPrincipal.userId
-        val room = roomService.getWalkthroughForDownload(roomId, userId)
+        val room = roomService.getWalkthroughForDownload(roomService.resolveRoomUrlId(roomId), userId)
         val filePath = room.walkthroughFilePath
 
         if (filePath == null || !uploadsService.fileExists(filePath)) {
@@ -407,59 +417,63 @@ class RoomController(
 
     @PostMapping("/{roomId}/server/start")
     fun startServer(
-        @PathVariable roomId: Long,
+        @PathVariable roomId: String,
         principal: Principal,
         exchange: ServerWebExchange,
         model: Model,
     ): Mono<String> = mono {
         val userId = principal.asDiscordPrincipal.userId
-        handleRoomAction(roomId, userId, exchange, model) {
-            roomService.startServer(roomId, userId)
+        handleRoomAction(roomId, userId, exchange, model) { internalRoomId ->
+            roomService.startServer(internalRoomId, userId)
         }
     }
 
     @PostMapping("/{roomId}/server/stop")
     fun stopServer(
-        @PathVariable roomId: Long,
+        @PathVariable roomId: String,
         principal: Principal,
         exchange: ServerWebExchange,
         model: Model,
     ): Mono<String> = mono {
         val userId = principal.asDiscordPrincipal.userId
-        handleRoomAction(roomId, userId, exchange, model) {
-            roomService.stopServer(roomId, userId)
+        handleRoomAction(roomId, userId, exchange, model) { internalRoomId ->
+            roomService.stopServer(internalRoomId, userId)
         }
     }
 
     private suspend fun handleRoomAction(
-        roomId: Long,
+        roomUrlId: String,
         userId: Long,
         exchange: ServerWebExchange,
         model: Model,
-        action: suspend () -> Unit,
-    ): String = try {
-        action()
-        "redirect:/rooms/$roomId"
-    } catch (e: ResponseStatusException) {
-        if (e.statusCode != HttpStatus.BAD_REQUEST && e.statusCode != HttpStatus.CONFLICT) {
-            throw e
-        }
+        action: suspend (Long) -> Unit,
+    ): String {
+        val internalRoomId = roomService.resolveRoomUrlId(roomUrlId)
+        return try {
+            action(internalRoomId)
+            "redirect:/rooms/$roomUrlId"
+        } catch (e: ResponseStatusException) {
+            if (e.statusCode != HttpStatus.BAD_REQUEST && e.statusCode != HttpStatus.CONFLICT) {
+                throw e
+            }
 
-        loadRoomModel(roomId, userId, model, exchange)
-        model.addAttribute("errorMessage", e.reason ?: "An error occurred")
-        "room"
+            loadRoomModel(internalRoomId, userId, model, exchange, roomUrlId)
+            model.addAttribute("errorMessage", e.reason ?: "An error occurred")
+            "room"
+        }
     }
 
     @PostMapping("/{roomId}/delete")
     fun deleteRoom(
-        @PathVariable roomId: Long,
+        @PathVariable roomId: String,
         principal: Principal
     ): Mono<String> = mono {
         val userId = principal.asDiscordPrincipal.userId
         // Stop the server first (outside the delete's transaction) so its shutdown
         // wait doesn't hold the DB connection open.
-        roomService.stopServer(roomId, userId)
-        roomService.deleteRoom(roomId, userId)
+        val internalRoomId = roomService.resolveRoomUrlId(roomId)
+        roomService.stopServer(internalRoomId, userId)
+        roomService.deleteRoom(internalRoomId, userId)
         "redirect:/"
     }
 
@@ -469,7 +483,13 @@ class RoomController(
         model.addAttribute("joinableRooms", roomService.getJoinableRooms(userId))
     }
 
-    private suspend fun loadRoomModel(roomId: Long, userId: Long, model: Model, exchange: ServerWebExchange) {
+    private suspend fun loadRoomModel(
+        roomId: Long,
+        userId: Long,
+        model: Model,
+        exchange: ServerWebExchange,
+        roomUrlId: String = roomId.toString(),
+    ) {
         val roomWithEntries = roomService.getRoom(roomId, userId)
         model.addAttribute("room", roomWithEntries.room)
         model.addAttribute("entries", roomWithEntries.entries.toList())
@@ -484,7 +504,7 @@ class RoomController(
             val uri = exchange.request.uri
             val host = uri.host + if (uri.port > 0) ":${uri.port}" else ""
             val scheme = if (uri.scheme == "https") "wss" else "ws"
-            "$scheme://$host/rooms/$roomId/ws"
+            "$scheme://$host/rooms/$roomUrlId/ws"
         } else {
             null
         }

--- a/src/main/kotlin/com/github/derminator/archipelobby/data/Room.kt
+++ b/src/main/kotlin/com/github/derminator/archipelobby/data/Room.kt
@@ -15,12 +15,14 @@ data class Room(
     val generatedGameFilePath: String? = null,
     val walkthroughFilePath: String? = null,
     @Version val version: Long? = null,
+    val publicId: String? = null,
 ) {
     companion object {
         const val GENERATING_SENTINEL = "__generating__"
     }
     val isGenerating: Boolean get() = generatedGameFilePath == GENERATING_SENTINEL
     val isGenerated: Boolean get() = generatedGameFilePath != null && !isGenerating
+    val urlId: String get() = publicId ?: id?.toString() ?: error("Room has no ID")
 }
 
 @Table("ENTRIES")
@@ -36,6 +38,7 @@ data class Entry(
 
 interface RoomRepository : ReactiveCrudRepository<Room, Long> {
     fun findByGuildId(guildId: Long): Flux<Room>
+    fun findByPublicId(publicId: String): Mono<Room>
     fun existsByGuildIdAndName(guildId: Long, name: String): Mono<Boolean>
     fun findByGeneratedGameFilePathIsNotNull(): Flux<Room>
 }

--- a/src/main/kotlin/com/github/derminator/archipelobby/data/RoomService.kt
+++ b/src/main/kotlin/com/github/derminator/archipelobby/data/RoomService.kt
@@ -25,6 +25,7 @@ import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.server.ResponseStatusException
+import java.util.UUID
 
 @Service
 class RoomService(
@@ -40,6 +41,23 @@ class RoomService(
     private val saveDataService: SaveDataService,
 ) {
     private val logger = LoggerFactory.getLogger(RoomService::class.java)
+
+    /** Resolves a public UUID, or a legacy numeric URL for a pre-UUID room. */
+    suspend fun resolveRoomUrlId(urlId: String): Long {
+        val normalizedUuid = runCatching { UUID.fromString(urlId).toString() }
+            .getOrNull()
+            ?.takeIf { it.equals(urlId, ignoreCase = true) }
+
+        val room = if (normalizedUuid != null) {
+            roomRepository.findByPublicId(normalizedUuid).awaitSingleOrNull()
+        } else {
+            val legacyId = urlId.toLongOrNull()
+                ?: throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid room ID")
+            roomRepository.findById(legacyId).awaitSingleOrNull()
+                ?.takeIf { it.publicId == null }
+        }
+        return room?.id ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "Room not found")
+    }
 
     suspend fun getRoomsForUser(userId: Long): List<Room> {
         return entryRepository.findByUserId(userId)
@@ -79,7 +97,9 @@ class RoomService(
             throw ResponseStatusException(HttpStatus.CONFLICT, "A room with this name already exists in this guild")
         }
 
-        return roomRepository.save(Room(guildId = guildId, name = name)).awaitSingle()
+        return roomRepository.save(
+            Room(guildId = guildId, name = name, publicId = UUID.randomUUID().toString()),
+        ).awaitSingle()
     }
 
     private suspend fun isRoomJoinable(room: Room, userId: Long): Boolean =
@@ -181,9 +201,12 @@ class RoomService(
     }
 
     @Transactional
-    suspend fun deleteEntry(entryId: Long, userId: Long) {
+    suspend fun deleteEntry(entryId: Long, roomId: Long, userId: Long) {
         val entry = entryRepository.findById(entryId).awaitSingleOrNull()
             ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "Entry not found")
+        if (entry.roomId != roomId) {
+            throw ResponseStatusException(HttpStatus.FORBIDDEN, "Entry does not belong to this room")
+        }
         val room = roomRepository.findById(entry.roomId).awaitSingle()
         val isAdmin = discordService.isAdminOfGuild(userId, room.guildId)
 
@@ -332,9 +355,12 @@ class RoomService(
     }
 
     @Transactional
-    suspend fun deleteApWorld(apWorldId: Long, userId: Long) {
+    suspend fun deleteApWorld(apWorldId: Long, roomId: Long, userId: Long) {
         val apWorld = apWorldRepository.findById(apWorldId).awaitSingleOrNull()
             ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "APWorld not found")
+        if (apWorld.roomId != roomId) {
+            throw ResponseStatusException(HttpStatus.FORBIDDEN, "APWorld does not belong to this room")
+        }
         val room = roomRepository.findById(apWorld.roomId).awaitSingle()
         val isAdmin = discordService.isAdminOfGuild(userId, room.guildId)
 

--- a/src/main/kotlin/com/github/derminator/archipelobby/multiserver/MultiServerProxyHandler.kt
+++ b/src/main/kotlin/com/github/derminator/archipelobby/multiserver/MultiServerProxyHandler.kt
@@ -1,6 +1,8 @@
 package com.github.derminator.archipelobby.multiserver
 
+import com.github.derminator.archipelobby.data.RoomService
 import jakarta.annotation.PreDestroy
+import kotlinx.coroutines.reactor.mono
 import org.slf4j.LoggerFactory
 import org.springframework.core.io.buffer.DataBufferFactory
 import org.springframework.stereotype.Component
@@ -9,6 +11,7 @@ import org.springframework.web.reactive.socket.WebSocketHandler
 import org.springframework.web.reactive.socket.WebSocketMessage
 import org.springframework.web.reactive.socket.WebSocketSession
 import org.springframework.web.reactive.socket.client.ReactorNettyWebSocketClient
+import org.springframework.web.server.ResponseStatusException
 import reactor.core.publisher.Mono
 import reactor.netty.http.client.HttpClient
 import reactor.netty.resources.ConnectionProvider
@@ -24,6 +27,7 @@ import java.net.URI
 class MultiServerProxyHandler(
     private val multiServerManager: MultiServerManager,
     private val properties: MultiServerProperties,
+    private val roomService: RoomService,
 ) : WebSocketHandler {
 
     private val logger = LoggerFactory.getLogger(MultiServerProxyHandler::class.java)
@@ -36,13 +40,17 @@ class MultiServerProxyHandler(
     }
 
     override fun handle(session: WebSocketSession): Mono<Void> {
-        val roomId = extractRoomId(session) ?: return session.close(CloseStatus.NOT_ACCEPTABLE)
-        // getServerPort returns null once the room's process has exited, so a
-        // missing port means "no live server" — ask the client to reconnect.
-        // Only this branch closes with SERVICE_RESTARTED; a normal proxy()
-        // completion just propagates its Mono<Void>.
-        val port = activePort(roomId) ?: return session.close(CloseStatus.SERVICE_RESTARTED)
-        return proxy(session, port)
+        val roomUrlId = extractRoomUrlId(session) ?: return session.close(CloseStatus.NOT_ACCEPTABLE)
+        return mono { roomService.resolveRoomUrlId(roomUrlId) }
+            .flatMap { roomId ->
+                // getServerPort returns null once the room's process has exited, so a
+                // missing port means "no live server" — ask the client to reconnect.
+                val port = activePort(roomId) ?: return@flatMap session.close(CloseStatus.SERVICE_RESTARTED)
+                proxy(session, port)
+            }
+            .onErrorResume(ResponseStatusException::class.java) {
+                session.close(CloseStatus.NOT_ACCEPTABLE)
+            }
     }
 
     private fun activePort(roomId: Long): Int? = multiServerManager.getServerPort(roomId)
@@ -56,13 +64,13 @@ class MultiServerProxyHandler(
         }.doOnError { e -> logger.warn("WebSocket proxy error", e) }
     }
 
-    private fun extractRoomId(session: WebSocketSession): Long? {
+    private fun extractRoomUrlId(session: WebSocketSession): String? {
         val match = ROOM_PATH_REGEX.matchEntire(session.handshakeInfo.uri.path) ?: return null
-        return match.groupValues[1].toLongOrNull()
+        return match.groupValues[1]
     }
 
     companion object {
-        private val ROOM_PATH_REGEX = Regex("""/rooms/(\d+)/ws""")
+        private val ROOM_PATH_REGEX = Regex("""/rooms/([^/]+)/ws""")
     }
 }
 

--- a/src/main/resources/db/migration/V12__AddRoomPublicIds.sql
+++ b/src/main/resources/db/migration/V12__AddRoomPublicIds.sql
@@ -1,0 +1,2 @@
+ALTER TABLE ROOMS ADD COLUMN public_id VARCHAR(36);
+ALTER TABLE ROOMS ADD CONSTRAINT uq_rooms_public_id UNIQUE (public_id);

--- a/src/main/resources/templates/room.html
+++ b/src/main/resources/templates/room.html
@@ -31,7 +31,7 @@
 
     <div th:if="${room.isGenerated}">
         <h2>Generated Game</h2>
-        <a th:href="@{/rooms/{id}/generated-game/download(id=${room.id})}">
+        <a th:href="@{/rooms/{id}/generated-game/download(id=${room.urlId})}">
             <button type="button">Download Game</button>
         </a>
 
@@ -47,12 +47,12 @@
         <div th:if="${isAdmin}" class="button-row">
             <form th:if="${serverAddress == null}" method="post"
                   class="inline-form"
-                  th:action="@{/rooms/{id}/server/start(id=${room.id})}">
+                  th:action="@{/rooms/{id}/server/start(id=${room.urlId})}">
                 <input type="submit" value="Start Server"/>
             </form>
             <form th:if="${serverAddress != null}" method="post"
                   class="inline-form"
-                  th:action="@{/rooms/{id}/server/stop(id=${room.id})}"
+                  th:action="@{/rooms/{id}/server/stop(id=${room.urlId})}"
                   th:attr="data-confirm='Stop the server? Connected players will be disconnected.'">
                 <input type="submit" value="Stop Server"/>
             </form>
@@ -64,7 +64,7 @@
     </div>
 
     <h2>Entries</h2>
-    <a th:href="@{/rooms/{roomId}/download(roomId=${room.id})}">
+    <a th:href="@{/rooms/{roomId}/download(roomId=${room.urlId})}">
         <button type="button">Download YAMLs + APWorlds</button>
     </a>
     <ul>
@@ -73,16 +73,16 @@
             (<span th:text="${entry.game}">Game</span>,
              <span th:text="${entry.user.username}">Username</span>)
             <span th:text="| - ${entry.locationCount} locations|"></span>
-            <a th:href="@{/rooms/{roomId}/entries/{entryId}/download(roomId=${room.id},entryId=${entry.id})}">
+            <a th:href="@{/rooms/{roomId}/entries/{entryId}/download(roomId=${room.urlId},entryId=${entry.id})}">
                 <button type="button">Download YAML</button>
             </a>
             <a th:each="patch : ${entry.patches}"
-               th:href="@{/rooms/{roomId}/patches/{patchId}/download(roomId=${room.id},patchId=${patch.id})}">
+               th:href="@{/rooms/{roomId}/patches/{patchId}/download(roomId=${room.urlId},patchId=${patch.id})}">
                 <button type="button" th:text="|Download ${patch.fileName}|">Download Patch</button>
             </a>
             <form method="post"
                   class="inline-form"
-                  th:action="@{/rooms/{roomId}/entries/{entryId}/delete(roomId=${room.id},entryId=${entry.id})}"
+                  th:action="@{/rooms/{roomId}/entries/{entryId}/delete(roomId=${room.urlId},entryId=${entry.id})}"
                   th:if="${(entry.user.id == userId or isAdmin) and room.generatedGameFilePath == null}"
                   th:attr="data-confirm=|Delete entry '${entry.name}'?|">
                 <input type="submit" value="Delete"/>
@@ -96,12 +96,12 @@
         <li th:each="apWorld : ${apWorlds}">
             <strong th:text="${apWorld.fileName}">Filename</strong>
             (<span th:text="${apWorld.user.username}">Username</span>)
-            <a th:href="@{/rooms/{roomId}/apworlds/{apworldId}/download(roomId=${room.id},apworldId=${apWorld.id})}">
+            <a th:href="@{/rooms/{roomId}/apworlds/{apworldId}/download(roomId=${room.urlId},apworldId=${apWorld.id})}">
                 <button type="button">Download</button>
             </a>
             <form method="post"
                   class="inline-form"
-                  th:action="@{/rooms/{roomId}/apworlds/{apworldId}/delete(roomId=${room.id},apworldId=${apWorld.id})}"
+                  th:action="@{/rooms/{roomId}/apworlds/{apworldId}/delete(roomId=${room.urlId},apworldId=${apWorld.id})}"
                   th:if="${(apWorld.user.id == userId or isAdmin) and room.generatedGameFilePath == null}"
                   th:attr="data-confirm=|Delete APWorld '${apWorld.fileName}'?|">
                 <input type="submit" value="Delete"/>
@@ -111,7 +111,7 @@
 
     <div th:if="${room.generatedGameFilePath == null}">
         <h3>Add Entry</h3>
-        <div th:replace="~{layout :: add-entry-form(${room.id})}"></div>
+        <div th:replace="~{layout :: add-entry-form(${room.urlId})}"></div>
     </div>
     <div th:if="${room.isGenerating}">
         <p>Game generation is in progress — submissions are temporarily closed.</p>
@@ -127,14 +127,14 @@
             <h3>Game Generation</h3>
             <form method="post"
                   th:if="${not #lists.isEmpty(entries)}"
-                  th:action="@{/rooms/{id}/generate(id=${room.id})}"
+                  th:action="@{/rooms/{id}/generate(id=${room.urlId})}"
                   th:attr="data-confirm=|Generate the Archipelago game for '${room.name}'? Submissions will be locked.|">
                 <input type="submit" value="Generate Game"/>
             </form>
             <form method="post"
                   enctype="multipart/form-data"
                   th:if="${not #lists.isEmpty(entries)}"
-                  th:action="@{/rooms/{id}/upload-game(id=${room.id})}">
+                  th:action="@{/rooms/{id}/upload-game(id=${room.urlId})}">
                 <label>
                     Upload game file (.archipelago or .zip):
                     <input type="file" name="gameFile" accept=".archipelago,.zip" required/>
@@ -155,12 +155,12 @@
             <h3>Generated Game</h3>
             <div class="button-row">
                 <a th:if="${room.walkthroughFilePath != null}"
-                   th:href="@{/rooms/{id}/walkthrough/download(id=${room.id})}">
+                   th:href="@{/rooms/{id}/walkthrough/download(id=${room.urlId})}">
                     <button type="button">Download Walkthrough</button>
                 </a>
                 <form method="post"
                       class="inline-form"
-                      th:action="@{/rooms/{id}/generated-game/delete(id=${room.id})}"
+                      th:action="@{/rooms/{id}/generated-game/delete(id=${room.urlId})}"
                       th:attr="data-confirm=|Delete the generated game for '${room.name}'? Submissions will reopen.|">
                     <input type="submit" value="Delete Generated Game"/>
                 </form>
@@ -169,7 +169,7 @@
 
         <h3>Room Management</h3>
         <form method="post"
-              th:action="@{/rooms/{id}/delete(id=${room.id})}"
+              th:action="@{/rooms/{id}/delete(id=${room.urlId})}"
               th:attr="data-confirm=|Delete room '${room.name}'? This cannot be undone.|">
             <input type="submit" value="Delete Room"/>
         </form>

--- a/src/main/resources/templates/rooms.html
+++ b/src/main/resources/templates/rooms.html
@@ -15,7 +15,7 @@
         <h2>Your Rooms</h2>
         <ul>
             <li th:each="room : ${userRooms}">
-                <a th:href="@{/rooms/{id}(id=${room.id})}" th:text="${room.name}">Room Name</a>
+                <a th:href="@{/rooms/{id}(id=${room.urlId})}" th:text="${room.name}">Room Name</a>
             </li>
         </ul>
     </div>
@@ -24,7 +24,7 @@
         <h2>Join a Room</h2>
         <ul>
             <li th:each="room : ${joinableRooms}">
-                <a th:href="@{/rooms/{id}(id=${room.id})}" th:text="${room.name}">Room Name</a>
+                <a th:href="@{/rooms/{id}(id=${room.urlId})}" th:text="${room.name}">Room Name</a>
             </li>
         </ul>
     </div>

--- a/src/test/kotlin/com/github/derminator/archipelobby/WebTests.kt
+++ b/src/test/kotlin/com/github/derminator/archipelobby/WebTests.kt
@@ -255,6 +255,51 @@ class WebTests {
     }
 
     @Test
+    fun `UUID room URL loads the room preview`(): Unit = runBlocking {
+        val publicId = "550e8400-e29b-41d4-a716-446655440000"
+        val room = Room(id = 42L, guildId = 123L, name = "UUID Room", publicId = publicId)
+        `when`(roomRepository.findByPublicId(publicId)).thenReturn(Mono.just(room))
+        `when`(roomRepository.findById(42L)).thenReturn(Mono.just(room))
+        `when`(entryRepository.findByRoomId(42L)).thenReturn(Flux.empty())
+
+        webTestClient.get().uri("/rooms/$publicId")
+            .exchange()
+            .expectStatus().isOk
+            .expectBody<String>().consumeWith { response ->
+                assert(response.responseBody!!.contains("UUID Room"))
+            }
+    }
+
+    @Test
+    fun `legacy numeric room URL still loads a room without a public ID`(): Unit = runBlocking {
+        val room = Room(id = 42L, guildId = 123L, name = "Legacy Room")
+        `when`(roomRepository.findById(42L)).thenReturn(Mono.just(room))
+        `when`(entryRepository.findByRoomId(42L)).thenReturn(Flux.empty())
+
+        webTestClient.get().uri("/rooms/42")
+            .exchange()
+            .expectStatus().isOk
+            .expectBody<String>().consumeWith { response ->
+                assert(response.responseBody!!.contains("Legacy Room"))
+            }
+    }
+
+    @Test
+    fun `numeric database ID does not expose a UUID room`(): Unit = runBlocking {
+        val room = Room(
+            id = 42L,
+            guildId = 123L,
+            name = "UUID Room",
+            publicId = "550e8400-e29b-41d4-a716-446655440000",
+        )
+        `when`(roomRepository.findById(42L)).thenReturn(Mono.just(room))
+
+        webTestClient.get().uri("/rooms/42")
+            .exchange()
+            .expectStatus().isNotFound
+    }
+
+    @Test
     fun `adding entry with duplicate name returns error banner in room page`(): Unit = runBlocking {
         val roomId = 1L
         `when`(entryRepository.existsByRoomIdAndName(anyLong(), anyString())).thenReturn(Mono.just(true))
@@ -325,6 +370,130 @@ class WebTests {
                 assert(body != null)
                 assert(body!!.contains("class=\"error-banner\""))
                 assert(body.contains("Unknown Game") && body.contains("not supported"))
+            }
+    }
+
+    @Test
+    fun `entry cannot be deleted through a different room URL`(): Unit = runBlocking {
+        val publicId = "550e8400-e29b-41d4-a716-446655440000"
+        val routeRoom = Room(id = 42L, guildId = 123L, name = "Route Room", publicId = publicId)
+        val owningRoom = Room(id = 99L, guildId = 123L, name = "Owning Room")
+        val entry = Entry(id = 7L, roomId = 99L, userId = testPrincipal.userId, name = "Player", game = "Game", yamlFilePath = "player.yaml")
+        `when`(roomRepository.findByPublicId(publicId)).thenReturn(Mono.just(routeRoom))
+        `when`(roomRepository.findById(99L)).thenReturn(Mono.just(owningRoom))
+        `when`(entryRepository.findById(7L)).thenReturn(Mono.just(entry))
+        `when`(entryRepository.deleteById(7L)).thenReturn(Mono.empty())
+
+        webTestClient.mutateWith(
+            mockAuthentication(
+                UsernamePasswordAuthenticationToken(
+                    testPrincipal,
+                    null,
+                    listOf(SimpleGrantedAuthority("ROLE_USER")),
+                ),
+            ),
+        )
+            .mutateWith(csrf())
+            .post().uri("/rooms/$publicId/entries/7/delete")
+            .exchange()
+            .expectStatus().isForbidden
+
+        verify(entryRepository, never()).deleteById(7L)
+    }
+
+    @Test
+    fun `APWorld cannot be deleted through a different room URL`(): Unit = runBlocking {
+        val publicId = "550e8400-e29b-41d4-a716-446655440000"
+        val routeRoom = Room(id = 42L, guildId = 123L, name = "Route Room", publicId = publicId)
+        val owningRoom = Room(id = 99L, guildId = 123L, name = "Owning Room")
+        val apWorld = ApWorld(
+            id = 7L,
+            roomId = 99L,
+            userId = testPrincipal.userId,
+            fileName = "game.apworld",
+            filePath = "game.apworld",
+            gameName = "Game",
+        )
+        `when`(roomRepository.findByPublicId(publicId)).thenReturn(Mono.just(routeRoom))
+        `when`(roomRepository.findById(99L)).thenReturn(Mono.just(owningRoom))
+        `when`(apWorldRepository.findById(7L)).thenReturn(Mono.just(apWorld))
+        `when`(apWorldRepository.deleteById(7L)).thenReturn(Mono.empty())
+
+        webTestClient.mutateWith(
+            mockAuthentication(
+                UsernamePasswordAuthenticationToken(
+                    testPrincipal,
+                    null,
+                    listOf(SimpleGrantedAuthority("ROLE_USER")),
+                ),
+            ),
+        )
+            .mutateWith(csrf())
+            .post().uri("/rooms/$publicId/apworlds/7/delete")
+            .exchange()
+            .expectStatus().isForbidden
+
+        verify(apWorldRepository, never()).deleteById(7L)
+    }
+
+    @Test
+    fun `creating a room redirects to a UUID URL`(): Unit = runBlocking {
+        `when`(discordService.isAdminOfGuild(testPrincipal.userId, 123L)).thenReturn(true)
+        `when`(roomRepository.existsByGuildIdAndName(123L, "Test Room")).thenReturn(Mono.just(false))
+        `when`(roomRepository.save(any(Room::class.java))).thenAnswer { invocation ->
+            Mono.just(invocation.getArgument<Room>(0).copy(id = 1L))
+        }
+
+        webTestClient.mutateWith(
+            mockAuthentication(
+                UsernamePasswordAuthenticationToken(
+                    testPrincipal,
+                    null,
+                    listOf(SimpleGrantedAuthority("ROLE_USER"))
+                )
+            )
+        )
+            .mutateWith(csrf())
+            .post().uri("/rooms")
+            .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+            .body(BodyInserters.fromFormData("guildId", "123").with("name", "Test Room"))
+            .exchange()
+            .expectStatus().is3xxRedirection
+            .expectHeader().valueMatches(
+                "Location",
+                "/rooms/[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}",
+            )
+    }
+
+    @Test
+    fun `rooms page links UUID rooms by public ID and legacy rooms by numeric ID`(): Unit = runBlocking {
+        val publicId = "550e8400-e29b-41d4-a716-446655440000"
+        `when`(discordService.getGuildsForUser(testPrincipal.userId)).thenReturn(flowOf(GuildInfo(123L, "Guild")))
+        `when`(roomRepository.findByGuildId(123L)).thenReturn(
+            Flux.just(
+                Room(id = 42L, guildId = 123L, name = "Legacy Room"),
+                Room(id = 43L, guildId = 123L, name = "UUID Room", publicId = publicId),
+            ),
+        )
+        `when`(entryRepository.countByRoomIdAndUserId(anyLong(), anyLong())).thenReturn(Mono.just(0L))
+
+        webTestClient.mutateWith(
+            mockAuthentication(
+                UsernamePasswordAuthenticationToken(
+                    testPrincipal,
+                    null,
+                    listOf(SimpleGrantedAuthority("ROLE_USER")),
+                ),
+            ),
+        )
+            .get().uri("/rooms")
+            .exchange()
+            .expectStatus().isOk
+            .expectBody<String>().consumeWith { response ->
+                val body = response.responseBody!!
+                assert(body.contains("href=\"/rooms/42\""))
+                assert(body.contains("href=\"/rooms/$publicId\""))
+                assert(!body.contains("href=\"/rooms/43\""))
             }
     }
 

--- a/src/test/kotlin/com/github/derminator/archipelobby/multiserver/MultiServerProxyHandlerTest.kt
+++ b/src/test/kotlin/com/github/derminator/archipelobby/multiserver/MultiServerProxyHandlerTest.kt
@@ -1,16 +1,69 @@
 package com.github.derminator.archipelobby.multiserver
 
+import com.github.derminator.archipelobby.data.RoomService
 import io.netty.buffer.PooledByteBufAllocator
+import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
 import org.springframework.core.io.buffer.DataBufferUtils
 import org.springframework.core.io.buffer.DefaultDataBufferFactory
 import org.springframework.core.io.buffer.NettyDataBufferFactory
+import org.springframework.http.HttpStatus
 import org.springframework.web.reactive.socket.WebSocketMessage
+import org.springframework.web.reactive.socket.CloseStatus
+import org.springframework.web.reactive.socket.HandshakeInfo
+import org.springframework.web.reactive.socket.WebSocketSession
+import org.springframework.web.server.ResponseStatusException
+import reactor.core.publisher.Mono
+import java.net.URI
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class MultiServerProxyHandlerTest {
+
+    @Test
+    fun `UUID websocket URL resolves to the internal room ID`(): Unit = runBlocking {
+        val publicId = "550e8400-e29b-41d4-a716-446655440000"
+        val roomService = mock(RoomService::class.java)
+        val manager = mock(MultiServerManager::class.java)
+        val session = mock(WebSocketSession::class.java)
+        val handshake = mock(HandshakeInfo::class.java)
+        `when`(session.handshakeInfo).thenReturn(handshake)
+        `when`(handshake.uri).thenReturn(URI("ws://localhost/rooms/$publicId/ws"))
+        `when`(roomService.resolveRoomUrlId(publicId)).thenReturn(42L)
+        `when`(manager.getServerPort(42L)).thenReturn(null)
+        `when`(session.close(CloseStatus.SERVICE_RESTARTED)).thenReturn(Mono.empty())
+
+        MultiServerProxyHandler(manager, MultiServerProperties(), roomService)
+            .handle(session)
+            .block()
+
+        verify(manager).getServerPort(42L)
+    }
+
+    @Test
+    fun `unknown websocket room closes as not acceptable`(): Unit = runBlocking {
+        val publicId = "550e8400-e29b-41d4-a716-446655440000"
+        val roomService = mock(RoomService::class.java)
+        val manager = mock(MultiServerManager::class.java)
+        val session = mock(WebSocketSession::class.java)
+        val handshake = mock(HandshakeInfo::class.java)
+        `when`(session.handshakeInfo).thenReturn(handshake)
+        `when`(handshake.uri).thenReturn(URI("ws://localhost/rooms/$publicId/ws"))
+        `when`(roomService.resolveRoomUrlId(publicId)).thenThrow(
+            ResponseStatusException(HttpStatus.NOT_FOUND, "Room not found"),
+        )
+        `when`(session.close(CloseStatus.NOT_ACCEPTABLE)).thenReturn(Mono.empty())
+
+        MultiServerProxyHandler(manager, MultiServerProperties(), roomService)
+            .handle(session)
+            .block()
+
+        verify(session).close(CloseStatus.NOT_ACCEPTABLE)
+    }
 
     @Test
     fun `copying a frame leaves source buffer ownership with receive pipeline`() {


### PR DESCRIPTION
## Summary
- Give newly created rooms random UUID public identifiers and URLs.
- Preserve existing numeric room URLs for legacy rooms.
- Resolve UUID and legacy identifiers across HTTP and WebSocket routes.
- Prevent cross-room entry/APWorld deletion through mismatched URLs.
- Add a nullable unique `public_id` Flyway migration.

## Verification
- `python -m unittest discover -s python -p "test_*.py"` — 3 tests passed
- `./gradlew test -x pythonTest --no-daemon` — JVM suite passed
- Focused UUID, legacy-compatibility, cross-room deletion, and WebSocket tests passed
- `git diff --check` passed

## Compatibility
Existing rooms retain their numeric IDs and URLs. New rooms use UUIDs without changing internal numeric foreign-key relationships.