### PR TITLE
fix: load APWorlds through Archipelago loader for location counts

### DIFF
--- a/python/get_location_count.py
+++ b/python/get_location_count.py
@@ -2,13 +2,13 @@
 """
 Get the location count for an Archipelago player YAML.
 
-Usage: get_location_count.py <archipelago_dir> <yaml_path> [<apworld_path>...]
+Usage: get_location_count.py <archipelago_dir> <yaml_path>
 
 Prints the integer location count on stdout.
 Exits non-zero if the game is unknown or initialization fails.
-APWorld paths are loaded before built-in worlds, so custom games are registered.
+Custom APWorlds must already be staged in <archipelago_dir>/custom_worlds,
+where Archipelago's native loader imports them under the worlds.* namespace.
 """
-import importlib
 import os
 import random as rand_module
 import sys
@@ -16,31 +16,17 @@ import typing
 
 
 def main():
-    if len(sys.argv) < 3:
-        print("Usage: get_location_count.py <archipelago_dir> <yaml_path> [<apworld_path>...]",
-              file=sys.stderr)
+    if len(sys.argv) != 3:
+        print("Usage: get_location_count.py <archipelago_dir> <yaml_path>", file=sys.stderr)
         sys.exit(1)
 
     archipelago_dir = os.path.abspath(sys.argv[1])
     yaml_path = os.path.abspath(sys.argv[2])
-    apworld_paths = [os.path.abspath(p) for p in sys.argv[3:]]
 
     sys.path.insert(0, archipelago_dir)
 
-    # Load APWorlds before built-in worlds so custom game classes are registered.
-    # .apworld files are ZIP packages; adding them to sys.path lets Python import
-    # them directly. Importing triggers the AutoWorld metaclass registration.
-    for apworld_path in apworld_paths:
-        if not os.path.isfile(apworld_path):
-            continue
-        sys.path.insert(0, apworld_path)
-        package_name = os.path.basename(apworld_path).removesuffix(".apworld")
-        try:
-            importlib.import_module(package_name)
-        except Exception as e:
-            print(f"Warning: could not load APWorld {apworld_path!r}: {e}", file=sys.stderr)
-
-    # Importing worlds registers all built-in game world classes.
+    # Archipelago discovers APWorlds from archipelago_dir/custom_worlds and
+    # imports them as worlds.<package>, preserving package resource access.
     import worlds  # noqa: E402, F401
     from worlds.AutoWorld import AutoWorldRegister
 

--- a/python/get_location_count.py
+++ b/python/get_location_count.py
@@ -49,14 +49,7 @@ def main():
     multiworld.game = {1: game_name}
     multiworld.player_name = {1: player_data.get("name", "Player")}
     multiworld.plando_options = PlandoOptions.none
-    multiworld.plando_items = [[]]
-    multiworld.plando_connections = [[]]
-    multiworld.re_gen_passthrough = {}
     multiworld.random = rand_module.Random()
-
-    # plando_texts was added in a later Archipelago version; set it if present.
-    if hasattr(multiworld, "plando_texts"):
-        multiworld.plando_texts = [[]]
 
     world = world_class(multiworld, 1)
     multiworld.worlds = {1: world}

--- a/src/main/kotlin/com/github/derminator/archipelobby/generator/RealArchipelagoGeneratorService.kt
+++ b/src/main/kotlin/com/github/derminator/archipelobby/generator/RealArchipelagoGeneratorService.kt
@@ -4,12 +4,14 @@ import com.github.derminator.archipelobby.extractFilesFromZip
 import jakarta.annotation.PostConstruct
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.web.server.ResponseStatusException
 import java.io.File
 import java.nio.file.Files
+import java.util.Locale
 
 @Service
 class RealArchipelagoGeneratorService(
@@ -18,6 +20,8 @@ class RealArchipelagoGeneratorService(
     @Value($$"${archipelobby.archipelago.location-count-script-path:python/get_location_count.py}") private val locationCountScriptPath: String,
     private val pythonScriptRunner: PythonScriptRunner,
 ) : ArchipelagoGeneratorService {
+
+    private val logger = LoggerFactory.getLogger(RealArchipelagoGeneratorService::class.java)
 
     @PostConstruct
     fun installDependencies() {
@@ -40,11 +44,8 @@ class RealArchipelagoGeneratorService(
             for ((name, bytes) in yamlFiles) {
                 playersDir.resolve(name).writeBytes(bytes)
             }
-            for ((name, bytes) in apWorldFiles) {
-                customWorldsDir.resolve(name).writeBytes(bytes)
-            }
+            writeApWorlds(customWorldsDir, apWorldFiles)
 
-            // Install any dependencies introduced by the current set of APWorlds.
             val moduleUpdateFile = File(moduleUpdateScriptPath).absoluteFile
             pythonScriptRunner.run(
                 workDir.resolve(moduleUpdateFile.name).path,
@@ -65,8 +66,6 @@ class RealArchipelagoGeneratorService(
                 "Archipelago generation produced no game zip",
             )
 
-            // The .archipelago multidata, the spoiler log, and the per-slot patch files all
-            // live inside the zip.
             val (archipelagoBytes, walkthroughBytes, patchFiles) = extractFilesFromZip(Files.readAllBytes(gameZip))
             val archipelago = archipelagoBytes
                 ?: throw ResponseStatusException(
@@ -81,30 +80,78 @@ class RealArchipelagoGeneratorService(
 
             GeneratedGame(archipelago, walkthrough, patchFiles)
         } finally {
-            workDir.deleteRecursively()
+            cleanupWorkDir(workDir)
         }
     }
 
     override suspend fun getLocationCount(yamlContent: ByteArray, apWorldContents: Map<String, ByteArray>): Int =
         withContext(Dispatchers.IO) {
-            val tempDir = Files.createTempDirectory("archipelago-loc-count-").toFile()
+            val workDir = Files.createTempDirectory("archipelago-loc-count-").toFile()
             try {
-                val yamlFile = tempDir.resolve("player.yaml").also { it.writeBytes(yamlContent) }
-                val apWorldPaths = apWorldContents.map { (name, bytes) ->
-                    tempDir.resolve(name).also { it.writeBytes(bytes) }.absolutePath
-                }
-                val archipelagoDir = File(scriptPath).absoluteFile.parent
-                val args = (listOf(archipelagoDir, yamlFile.absolutePath) + apWorldPaths).toTypedArray()
-                val output = pythonScriptRunner.run(File(locationCountScriptPath).absoluteFile.path, *args)
+                val archipelagoDir = File(scriptPath).absoluteFile.parentFile
+                archipelagoDir.copyRecursively(workDir, overwrite = true)
+
+                val yamlFile = workDir.resolve("player.yaml").also { it.writeBytes(yamlContent) }
+                val customWorldsDir = workDir.resolve("custom_worlds").also { it.mkdirs() }
+                writeApWorlds(customWorldsDir, apWorldContents)
+
+                val locationCountScript = File(locationCountScriptPath).absoluteFile
+                val scriptInWorkDir = workDir.resolve(locationCountScript.name)
+                locationCountScript.copyTo(scriptInWorkDir, overwrite = true)
+                val output = pythonScriptRunner.run(
+                    scriptInWorkDir.absolutePath,
+                    workDir.absolutePath,
+                    yamlFile.absolutePath,
+                )
                 parseLocationCount(output)
                     ?: throw ResponseStatusException(
                         HttpStatus.INTERNAL_SERVER_ERROR,
                         "Location count script produced unexpected output: ${output.trim()}",
                     )
             } finally {
-                tempDir.deleteRecursively()
+                cleanupWorkDir(workDir)
             }
         }
+
+    private fun writeApWorlds(customWorldsDir: File, apWorldContents: Map<String, ByteArray>) {
+        val customWorldsPath = customWorldsDir.toPath()
+        val seenNames = mutableSetOf<String>()
+        for ((name, bytes) in apWorldContents) {
+            if (!isSafeApWorldFilename(name) || !seenNames.add(name.lowercase(Locale.ROOT))) {
+                throw ResponseStatusException(
+                    HttpStatus.BAD_REQUEST,
+                    "APWorld filename must be a unique direct .apworld child of custom_worlds",
+                )
+            }
+            val target = customWorldsPath.resolve(name).normalize()
+            if (target.parent != customWorldsPath) {
+                throw ResponseStatusException(
+                    HttpStatus.BAD_REQUEST,
+                    "APWorld filename must be a unique direct .apworld child of custom_worlds",
+                )
+            }
+            Files.write(target, bytes)
+        }
+    }
+
+    private fun isSafeApWorldFilename(name: String): Boolean {
+        if (name.isBlank() || !name.endsWith(".apworld")) return false
+        if (name.any { it in "<>:\"/\\|?*" || it.isISOControl() }) return false
+
+        val baseName = name.substringBeforeLast('.').uppercase(Locale.ROOT)
+        return baseName !in WINDOWS_RESERVED_FILENAMES
+    }
+
+    private fun cleanupWorkDir(workDir: File) {
+        if (!workDir.deleteRecursively()) {
+            logger.warn("Failed to delete Archipelago temporary work directory: {}", workDir)
+        }
+    }
+
+    private companion object {
+        val WINDOWS_RESERVED_FILENAMES = setOf("CON", "PRN", "AUX", "NUL") +
+            (1..9).flatMap { listOf("COM$it", "LPT$it") }
+    }
 }
 
 /**

--- a/src/test/kotlin/com/github/derminator/archipelobby/generator/RealArchipelagoGeneratorServiceTest.kt
+++ b/src/test/kotlin/com/github/derminator/archipelobby/generator/RealArchipelagoGeneratorServiceTest.kt
@@ -1,10 +1,136 @@
 package com.github.derminator.archipelobby.generator
 
+import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.io.TempDir
+import org.springframework.http.HttpStatus
+import org.springframework.web.server.ResponseStatusException
+import java.io.ByteArrayOutputStream
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+import kotlin.io.path.createDirectories
+import kotlin.io.path.readBytes
+import kotlin.io.path.writeText
+import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class RealArchipelagoGeneratorServiceTest {
+
+    @Test
+    fun `loads APWorlds in worlds namespace when they read packaged resources`(@TempDir tempDir: Path) = runBlocking {
+        val archipelagoRoot = createFakeArchipelagoRoot(tempDir)
+        val service = RealArchipelagoGeneratorService(
+            scriptPath = archipelagoRoot.resolve("Generate.py").toString(),
+            moduleUpdateScriptPath = archipelagoRoot.resolve("ModuleUpdate.py").toString(),
+            locationCountScriptPath = Path.of("python/get_location_count.py").toAbsolutePath().toString(),
+            pythonScriptRunner = PythonScriptRunner(),
+        )
+
+        val locationCount = service.getLocationCount(
+            "game: Manifest Resource Game\n".toByteArray(),
+            mapOf("manifest_reader.apworld" to manifestReaderApworld()),
+        )
+
+        assertEquals(1, locationCount)
+    }
+
+    @Test
+    fun `stages APWorlds in custom worlds directory before counting locations`(@TempDir tempDir: Path) = runBlocking {
+        val archipelagoRoot = tempDir.resolve("Archipelago").also { it.createDirectories() }
+        val generateScript = archipelagoRoot.resolve("Generate.py").also { it.writeText("print('noop')") }
+        val locationCountScript = tempDir.resolve("python").also { it.createDirectories() }
+            .resolve("get_location_count.py").also { it.writeText("print('noop')") }
+        val yaml = "game: Manifest Resource Game\n".toByteArray()
+        val apworld = byteArrayOf(1, 2, 3)
+
+        val runner = object : PythonScriptRunner() {
+            override fun run(scriptPath: String, vararg args: String): String {
+                val workingRoot = Path.of(scriptPath).parent
+                assertTrue(Files.isRegularFile(workingRoot.resolve("Generate.py")))
+                assertContentEquals(apworld, workingRoot.resolve("custom_worlds/manifest-reader.apworld").readBytes())
+                assertEquals(workingRoot.toString(), args[0])
+                assertEquals(workingRoot.resolve("player.yaml").toString(), args[1])
+                return "42"
+            }
+        }
+        val service = RealArchipelagoGeneratorService(
+            scriptPath = generateScript.toString(),
+            moduleUpdateScriptPath = archipelagoRoot.resolve("ModuleUpdate.py").toString(),
+            locationCountScriptPath = locationCountScript.toString(),
+            pythonScriptRunner = runner,
+        )
+
+        assertEquals(42, service.getLocationCount(yaml, mapOf("manifest-reader.apworld" to apworld)))
+    }
+
+    @Test
+    fun `rejects APWorld filenames that are not direct apworld children`(@TempDir tempDir: Path) {
+        val archipelagoRoot = tempDir.resolve("Archipelago").also { it.createDirectories() }
+        val generateScript = archipelagoRoot.resolve("Generate.py").also { it.writeText("print('noop')") }
+        val locationCountScript = tempDir.resolve("python").also { it.createDirectories() }
+            .resolve("get_location_count.py").also { it.writeText("print('noop')") }
+        val service = RealArchipelagoGeneratorService(
+            scriptPath = generateScript.toString(),
+            moduleUpdateScriptPath = archipelagoRoot.resolve("ModuleUpdate.py").toString(),
+            locationCountScriptPath = locationCountScript.toString(),
+            pythonScriptRunner = object : PythonScriptRunner() {
+                override fun run(scriptPath: String, vararg args: String): String = error("runner must not be invoked")
+            },
+        )
+
+        listOf("../escaped.apworld", "/absolute.apworld", "C:\\escaped.apworld", "bad?.apworld", "CON.apworld", "not-an-apworld").forEach { filename ->
+            val exception = assertThrows<ResponseStatusException> {
+                runBlocking {
+                    service.getLocationCount(
+                        "game: Example\n".toByteArray(),
+                        mapOf(filename to byteArrayOf(1)),
+                    )
+                }
+            }
+            assertEquals(HttpStatus.BAD_REQUEST, exception.statusCode)
+        }
+
+        val collision = assertThrows<ResponseStatusException> {
+            runBlocking {
+                service.getLocationCount(
+                    "game: Example\n".toByteArray(),
+                    linkedMapOf("world.apworld" to byteArrayOf(1), "WORLD.apworld" to byteArrayOf(2)),
+                )
+            }
+        }
+        assertEquals(HttpStatus.BAD_REQUEST, collision.statusCode)
+    }
+
+    @Test
+    fun `rejects colliding APWorld filenames before generation`(@TempDir tempDir: Path) {
+        val archipelagoRoot = tempDir.resolve("Archipelago").also { it.createDirectories() }
+        val generateScript = archipelagoRoot.resolve("Generate.py").also { it.writeText("print('noop')") }
+        val locationCountScript = tempDir.resolve("python").also { it.createDirectories() }
+            .resolve("get_location_count.py").also { it.writeText("print('noop')") }
+        val service = RealArchipelagoGeneratorService(
+            scriptPath = generateScript.toString(),
+            moduleUpdateScriptPath = archipelagoRoot.resolve("ModuleUpdate.py").toString(),
+            locationCountScriptPath = locationCountScript.toString(),
+            pythonScriptRunner = object : PythonScriptRunner() {
+                override fun run(scriptPath: String, vararg args: String): String = error("runner must not be invoked")
+            },
+        )
+
+        val exception = assertThrows<ResponseStatusException> {
+            runBlocking {
+                service.generate(
+                    emptyMap(),
+                    linkedMapOf("world.apworld" to byteArrayOf(1), "WORLD.apworld" to byteArrayOf(2)),
+                )
+            }
+        }
+        assertEquals(HttpStatus.BAD_REQUEST, exception.statusCode)
+    }
 
     @Test
     fun `parses location count after world generation warning`() {
@@ -19,5 +145,92 @@ class RealArchipelagoGeneratorServiceTest {
     @Test
     fun `rejects output whose final line is not a location count`() {
         assertNull(parseLocationCount("760\nunexpected output"))
+    }
+
+    private fun createFakeArchipelagoRoot(tempDir: Path): Path {
+        val root = tempDir.resolve("Archipelago").also { it.createDirectories() }
+        root.resolve("Generate.py").writeText("print('noop')")
+        root.resolve("BaseClasses.py").writeText(
+            """
+            class PlandoOptions:
+                none = 0
+
+            class MultiWorld:
+                def __init__(self, players):
+                    self.players = players
+                def get_locations(self, player):
+                    return [type("Location", (), {"address": 1})()]
+
+            class CollectionState:
+                def __init__(self, multiworld):
+                    self.multiworld = multiworld
+            """.trimIndent(),
+        )
+        root.resolve("yaml.py").writeText(
+            """
+            def safe_load(stream):
+                return {"game": "Manifest Resource Game", "name": "Tester"}
+            """.trimIndent(),
+        )
+        val worlds = root.resolve("worlds").also { it.createDirectories() }
+        worlds.resolve("AutoWorld.py").writeText("class AutoWorldRegister:\n    world_types = {}\n")
+        worlds.resolve("__init__.py").writeText(
+            """
+            import importlib
+            import sys
+            import zipimport
+            from pathlib import Path
+
+            specs = {}
+            for archive in (Path(__file__).parent.parent / "custom_worlds").glob("*.apworld"):
+                importer = zipimport.zipimporter(str(archive))
+                name = f"worlds.{archive.stem}"
+                specs[name] = importer.find_spec(name)
+
+            class Finder:
+                def find_spec(self, fullname, path=None, target=None):
+                    return specs.get(fullname)
+
+            sys.meta_path.insert(0, Finder())
+            for name in specs:
+                importlib.import_module(name)
+            """.trimIndent(),
+        )
+        return root
+    }
+
+    private fun manifestReaderApworld(): ByteArray = ByteArrayOutputStream().use { bytes ->
+        ZipOutputStream(bytes).use { zip ->
+            zip.writeEntry(
+                "manifest_reader/__init__.py",
+                """
+                import json
+                import pkgutil
+                from worlds.AutoWorld import AutoWorldRegister
+
+                manifest = json.loads(pkgutil.get_data(__package__, "archipelago.json"))
+
+                class ManifestReaderWorld:
+                    def __init__(self, multiworld, player):
+                        self.multiworld = multiworld
+                        self.player = player
+                    def generate_early(self): pass
+                    def create_regions(self): pass
+                    def create_items(self): pass
+                    def generate_basic(self): pass
+                    def pre_fill(self): pass
+
+                AutoWorldRegister.world_types[manifest["game"]] = ManifestReaderWorld
+                """.trimIndent(),
+            )
+            zip.writeEntry("manifest_reader/archipelago.json", "{\"game\": \"Manifest Resource Game\"}")
+        }
+        bytes.toByteArray()
+    }
+
+    private fun ZipOutputStream.writeEntry(name: String, content: String) {
+        putNextEntry(ZipEntry(name))
+        write(content.toByteArray())
+        closeEntry()
     }
 }


### PR DESCRIPTION
## Summary
- stage uploaded APWorlds in an isolated copied Archipelago `custom_worlds` directory before deriving location counts
- let Archipelago load custom worlds as `worlds.<package>`, preserving packaged-resource lookups such as `pkgutil.get_data`
- reject unsafe APWorld filenames before writing temporary files and log failed temporary-workspace cleanup

## Regression coverage
- execute the actual location-count helper against a synthetic APWorld that reads `archipelago.json` through `pkgutil.get_data(__package__, ...)`
- cover custom-world staging and traversal, absolute-path, drive-prefix, and extension rejection

## Validation
- `./gradlew test -x pythonTest`
- `./gradlew check -x pythonTest`
- `./gradlew bootJar -x pythonTest`
- `python -m py_compile python/get_location_count.py`
- `python -m unittest discover -s python -p 'test_*.py' -v`\n\n`pythonTest` was excluded from Gradle commands locally because this Windows development environment has `python` but no `python3` executable; the equivalent Python tests were run directly.