### PR TITLE
Add an alternative bot-based login flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,8 @@ DATA_DIR=/path/to/data  # Defaults to ./data
 6. Copy the Bot Token
 7. Enable necessary bot permissions and invite the bot to your Discord server
 8. Set `ARCHIPELOBBY_BASE_URL` to the public origin of this application. The bot automatically registers a global
-   `/login` command; Discord may take up to one hour to make a new global command visible.
+   `/login` command; Discord may take up to one hour to make a new global command visible. Users can also DM `/login`
+   to the bot without waiting for the command to appear.
 
 ## Running the Application
 
@@ -148,8 +149,8 @@ image. This avoids an interactive dependency prompt when opening a room.
 
 ## Usage
 
-1. **Login**: Navigate to the application and login with Discord OAuth, or run `/login` in a server shared with the bot
-   and open its private, one-time link within five minutes
+1. **Login**: Navigate to the application and login with Discord OAuth, or request a private login link by running
+   `/login` in a server shared with the bot or by DMing `/login` to the bot. Open the one-time link within five minutes
 2. **Create Room**: Select a Discord guild you administer and create a new room
 3. **Upload YAML**: In a room, upload Archipelago YAML files with entry names. World-generation warnings emitted while validating a YAML do not prevent its upload.
 4. **Upload APWorlds**: Upload any custom `.apworld` files needed by the room's games

--- a/README.md
+++ b/README.md
@@ -37,11 +37,11 @@ uploaded YAMLs, and easily download individual or bundled entries.
 Most external dependencies (Discord, file storage, Archipelago generation) are hidden behind an interface with two
 implementations, selected by Spring profile:
 
-| Interface                    | Production impl                | Dev/test impl                          |
-|-------------------------------|---------------------------------|------------------------------------------|
-| `DiscordService`               | `RealDiscordService` (`discord` profile) | `DevDiscordService` (`!discord` profile, configured via `archipelobby.discord.dev.*` properties) |
-| `UploadsService`                | `FileSystemUploadsService`     | `InMemoryUploadsService`                  |
-| `ArchipelagoGeneratorService`   | `RealArchipelagoGeneratorService` (shells out to the `Archipelago` submodule via Python) | test doubles in `src/test` |
+| Interface                     | Production impl                                                                          | Dev/test impl                                                                                    |
+|-------------------------------|------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------|
+| `DiscordService`              | `RealDiscordService` (`discord` profile)                                                 | `DevDiscordService` (`!discord` profile, configured via `archipelobby.discord.dev.*` properties) |
+| `UploadsService`              | `FileSystemUploadsService`                                                               | `InMemoryUploadsService`                                                                         |
+| `ArchipelagoGeneratorService` | `RealArchipelagoGeneratorService` (shells out to the `Archipelago` submodule via Python) | test doubles in `src/test`                                                                       |
 
 The `prod` profile activates the `discord` profile group (see `application.properties`), which wires up the real
 Discord OAuth2/bot integration; the default `dev` profile uses the in-memory/simulated implementations so the app
@@ -65,7 +65,7 @@ to generate multiworlds. Clone with submodules included:
 git clone --recurse-submodules <repo-url>
 ```
 
-If you already cloned without `--recurse-submodules`, fetch it afterwards:
+If you already cloned without `--recurse-submodules`, fetch it afterward:
 
 ```bash
 git submodule update --init --recursive
@@ -118,7 +118,7 @@ export ARCHIPELOBBY_BASE_URL=http://localhost:8080
 ./gradlew bootRun
 ```
 
-By default the app runs with the `dev` profile active, which uses an in-memory H2 database and a simulated Discord
+By default, the app runs with the `dev` profile active, which uses an in-memory H2 database and a simulated Discord
 service (see `application-dev.properties`) so it can be run locally without real Discord credentials.
 
 ### Using Docker

--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ DISCORD_CLIENT_SECRET=your_discord_client_secret
 
 # Discord bot token (for guild membership/admin checks)
 DISCORD_BOT_TOKEN=your_discord_bot_token
+# Public application origin used in bot-generated login links
+ARCHIPELOBBY_BASE_URL=https://lobby.example.com
 # Optional: Data directory for uploads and database
 DATA_DIR=/path/to/data  # Defaults to ./data
 ```
@@ -97,6 +99,8 @@ DATA_DIR=/path/to/data  # Defaults to ./data
 5. Navigate to Bot settings and create a bot
 6. Copy the Bot Token
 7. Enable necessary bot permissions and invite the bot to your Discord server
+8. Set `ARCHIPELOBBY_BASE_URL` to the public origin of this application. The bot automatically registers a global
+   `/login` command; Discord may take up to one hour to make a new global command visible.
 
 ## Running the Application
 
@@ -107,6 +111,7 @@ DATA_DIR=/path/to/data  # Defaults to ./data
 export DISCORD_CLIENT_ID=your_client_id
 export DISCORD_CLIENT_SECRET=your_client_secret
 export DISCORD_BOT_TOKEN=your_bot_token
+export ARCHIPELOBBY_BASE_URL=http://localhost:8080
 
 # Run the application
 ./gradlew bootRun
@@ -126,6 +131,7 @@ docker run -p 8080:8080 \
   -e DISCORD_CLIENT_ID=your_client_id \
   -e DISCORD_CLIENT_SECRET=your_client_secret \
   -e DISCORD_BOT_TOKEN=your_bot_token \
+  -e ARCHIPELOBBY_BASE_URL=https://lobby.example.com \
   -v /path/to/data:/data \
   archipelobby
 ```
@@ -142,7 +148,8 @@ image. This avoids an interactive dependency prompt when opening a room.
 
 ## Usage
 
-1. **Login**: Navigate to the application and login with Discord
+1. **Login**: Navigate to the application and login with Discord OAuth, or run `/login` in a server shared with the bot
+   and open its private, one-time link within five minutes
 2. **Create Room**: Select a Discord guild you administer and create a new room
 3. **Upload YAML**: In a room, upload Archipelago YAML files with entry names. World-generation warnings emitted while validating a YAML do not prevent its upload.
 4. **Upload APWorlds**: Upload any custom `.apworld` files needed by the room's games

--- a/src/main/kotlin/com/github/derminator/archipelobby/SecurityConfiguration.kt
+++ b/src/main/kotlin/com/github/derminator/archipelobby/SecurityConfiguration.kt
@@ -8,6 +8,8 @@ import org.springframework.security.config.annotation.web.reactive.EnableWebFlux
 import org.springframework.security.config.web.server.ServerHttpSecurity
 import org.springframework.security.config.web.server.invoke
 import org.springframework.security.web.server.SecurityWebFilterChain
+import org.springframework.security.web.server.context.ServerSecurityContextRepository
+import org.springframework.security.web.server.context.WebSessionServerSecurityContextRepository
 import org.springframework.security.web.server.csrf.XorServerCsrfTokenRequestAttributeHandler
 import org.springframework.security.web.server.header.ReferrerPolicyServerHttpHeadersWriter
 import org.springframework.security.web.server.util.matcher.ServerWebExchangeMatcher
@@ -32,12 +34,19 @@ class SecurityConfiguration(
     }
 
     @Bean
-    fun springSecurityFilterChain(http: ServerHttpSecurity): SecurityWebFilterChain {
+    fun securityContextRepository(): ServerSecurityContextRepository = WebSessionServerSecurityContextRepository()
+
+    @Bean
+    fun springSecurityFilterChain(
+        http: ServerHttpSecurity,
+        securityContextRepository: ServerSecurityContextRepository
+    ): SecurityWebFilterChain {
         val isDiscordEnabled = environment.activeProfiles.contains("discord")
+        http.securityContextRepository(securityContextRepository)
 
         return http {
             authorizeExchange {
-                authorize(pathMatchers("/", "/error", "/style.css", "/robots.txt", "/favicon.svg"), permitAll)
+                authorize(pathMatchers("/", "/error", "/style.css", "/robots.txt", "/favicon.svg", "/login/bot"), permitAll)
                 authorize(pathMatchers(HttpMethod.GET, "/rooms/*"), permitAll)
                 authorize(pathMatchers("/internal/multiserver/**"), permitAll)
                 authorize(pathMatchers("/rooms/*/ws"), permitAll)

--- a/src/main/kotlin/com/github/derminator/archipelobby/controllers/BotLoginController.kt
+++ b/src/main/kotlin/com/github/derminator/archipelobby/controllers/BotLoginController.kt
@@ -1,0 +1,41 @@
+package com.github.derminator.archipelobby.controllers
+
+import com.github.derminator.archipelobby.security.BotLoginService
+import kotlinx.coroutines.reactor.awaitSingleOrNull
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.core.context.SecurityContextImpl
+import org.springframework.security.web.server.context.ServerSecurityContextRepository
+import org.springframework.stereotype.Controller
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.server.ResponseStatusException
+import org.springframework.web.server.ServerWebExchange
+
+@Controller
+class BotLoginController(
+    private val botLoginService: BotLoginService,
+    private val securityContextRepository: ServerSecurityContextRepository
+) {
+    @GetMapping("/login/bot")
+    suspend fun login(
+        @RequestParam token: String,
+        exchange: ServerWebExchange
+    ): String {
+        val principal = botLoginService.consume(token)
+            ?: throw ResponseStatusException(HttpStatus.UNAUTHORIZED, "Invalid or expired login link")
+        val authentication = UsernamePasswordAuthenticationToken(
+            principal,
+            null,
+            listOf(SimpleGrantedAuthority("ROLE_USER"))
+        )
+
+        exchange.response.headers[HttpHeaders.CACHE_CONTROL] = "no-store"
+        exchange.response.headers["Referrer-Policy"] = "no-referrer"
+        exchange.session.awaitSingleOrNull()?.changeSessionId()?.awaitSingleOrNull()
+        securityContextRepository.save(exchange, SecurityContextImpl(authentication)).awaitSingleOrNull()
+        return "redirect:/rooms"
+    }
+}

--- a/src/main/kotlin/com/github/derminator/archipelobby/discord/DiscordLoginBot.kt
+++ b/src/main/kotlin/com/github/derminator/archipelobby/discord/DiscordLoginBot.kt
@@ -1,0 +1,63 @@
+package com.github.derminator.archipelobby.discord
+
+import com.github.derminator.archipelobby.security.BotLoginService
+import discord4j.core.GatewayDiscordClient
+import discord4j.core.event.domain.interaction.ChatInputInteractionEvent
+import discord4j.discordjson.json.ApplicationCommandRequest
+import jakarta.annotation.PreDestroy
+import kotlinx.coroutines.reactor.mono
+import org.slf4j.LoggerFactory
+import org.springframework.context.annotation.Profile
+import org.springframework.stereotype.Component
+import reactor.core.Disposable
+
+@Component
+@Profile("discord")
+class DiscordLoginBot(
+    gateway: GatewayDiscordClient,
+    private val botLoginService: BotLoginService
+) {
+    private val logger = LoggerFactory.getLogger(DiscordLoginBot::class.java)
+    private val subscription: Disposable
+
+    init {
+        val command = ApplicationCommandRequest.builder()
+            .name(COMMAND_NAME)
+            .description("Get a one-time Archipelobby login link")
+            .build()
+        gateway.restClient.applicationId
+            .flatMap { applicationId ->
+                gateway.restClient.applicationService.createGlobalApplicationCommand(applicationId, command)
+            }
+            .doOnError { logger.error("Failed to register Discord /login command", it) }
+            .onErrorComplete()
+            .subscribe()
+
+        subscription = gateway.on(ChatInputInteractionEvent::class.java)
+            .filter { it.commandName == COMMAND_NAME }
+            .flatMap { event ->
+                event.deferReply().withEphemeral(true).then(
+                    mono { botLoginService.createLoginLink(event.interaction.user.id.asLong()).orEmpty() }
+                        .flatMap { link ->
+                            event.editReply(
+                                if (link.isNotEmpty()) "Use this one-time link to log in: $link"
+                                else "You must be a member of a server shared with this bot to log in."
+                            )
+                        }
+                ).onErrorResume { error ->
+                    logger.warn("Failed to handle Discord /login command", error)
+                    event.editReply("Unable to create a login link right now. Please try again.")
+                        .onErrorComplete()
+                }
+            }
+            .doOnError { logger.error("Discord /login command listener failed", it) }
+            .subscribe()
+    }
+
+    @PreDestroy
+    fun stop() = subscription.dispose()
+
+    companion object {
+        private const val COMMAND_NAME = "login"
+    }
+}

--- a/src/main/kotlin/com/github/derminator/archipelobby/discord/DiscordLoginBot.kt
+++ b/src/main/kotlin/com/github/derminator/archipelobby/discord/DiscordLoginBot.kt
@@ -3,6 +3,7 @@ package com.github.derminator.archipelobby.discord
 import com.github.derminator.archipelobby.security.BotLoginService
 import discord4j.core.GatewayDiscordClient
 import discord4j.core.event.domain.interaction.ChatInputInteractionEvent
+import discord4j.core.event.domain.message.MessageCreateEvent
 import discord4j.discordjson.json.ApplicationCommandRequest
 import jakarta.annotation.PreDestroy
 import kotlinx.coroutines.reactor.mono
@@ -10,6 +11,8 @@ import org.slf4j.LoggerFactory
 import org.springframework.context.annotation.Profile
 import org.springframework.stereotype.Component
 import reactor.core.Disposable
+import reactor.core.Disposables
+import reactor.core.publisher.Mono
 
 @Component
 @Profile("discord")
@@ -18,7 +21,7 @@ class DiscordLoginBot(
     private val botLoginService: BotLoginService
 ) {
     private val logger = LoggerFactory.getLogger(DiscordLoginBot::class.java)
-    private val subscription: Disposable
+    private val subscriptions: Disposable.Composite = Disposables.composite()
 
     init {
         val command = ApplicationCommandRequest.builder()
@@ -33,17 +36,11 @@ class DiscordLoginBot(
             .onErrorComplete()
             .subscribe()
 
-        subscription = gateway.on(ChatInputInteractionEvent::class.java)
+        subscriptions.add(gateway.on(ChatInputInteractionEvent::class.java)
             .filter { it.commandName == COMMAND_NAME }
             .flatMap { event ->
                 event.deferReply().withEphemeral(true).then(
-                    mono { botLoginService.createLoginLink(event.interaction.user.id.asLong()).orEmpty() }
-                        .flatMap { link ->
-                            event.editReply(
-                                if (link.isNotEmpty()) "Use this one-time link to log in: $link"
-                                else "You must be a member of a server shared with this bot to log in."
-                            )
-                        }
+                    loginResponse(event.interaction.user.id.asLong()).flatMap(event::editReply)
                 ).onErrorResume { error ->
                     logger.warn("Failed to handle Discord /login command", error)
                     event.editReply("Unable to create a login link right now. Please try again.")
@@ -51,11 +48,36 @@ class DiscordLoginBot(
                 }
             }
             .doOnError { logger.error("Discord /login command listener failed", it) }
-            .subscribe()
+            .subscribe())
+
+        subscriptions.add(gateway.on(MessageCreateEvent::class.java)
+            .filter { event ->
+                event.guildId.isEmpty &&
+                    event.message.content.trim().equals("/$COMMAND_NAME", ignoreCase = true) &&
+                    event.message.author.map { !it.isBot }.orElse(false)
+            }
+            .flatMap { event ->
+                val userId = event.message.author.orElseThrow().id.asLong()
+                loginResponse(userId)
+                    .flatMap { response -> event.message.channel.flatMap { it.createMessage(response) } }
+                    .onErrorResume { error ->
+                        logger.warn("Failed to handle Discord /login DM", error)
+                        event.message.channel.flatMap {
+                            it.createMessage("Unable to create a login link right now. Please try again.")
+                        }.onErrorComplete()
+                    }
+            }
+            .doOnError { logger.error("Discord /login DM listener failed", it) }
+            .subscribe())
     }
 
+    private fun loginResponse(userId: Long): Mono<String> =
+        mono { botLoginService.createLoginLink(userId) }
+            .map { "Use this one-time link to log in: $it" }
+            .switchIfEmpty(Mono.just("You must be a member of a server shared with this bot to log in."))
+
     @PreDestroy
-    fun stop() = subscription.dispose()
+    fun stop() = subscriptions.dispose()
 
     companion object {
         private const val COMMAND_NAME = "login"

--- a/src/main/kotlin/com/github/derminator/archipelobby/security/BotLoginService.kt
+++ b/src/main/kotlin/com/github/derminator/archipelobby/security/BotLoginService.kt
@@ -1,0 +1,68 @@
+package com.github.derminator.archipelobby.security
+
+import com.github.derminator.archipelobby.discord.DiscordService
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.stereotype.Component
+import org.springframework.stereotype.Service
+import java.security.SecureRandom
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.util.Base64
+import java.util.concurrent.ConcurrentHashMap
+
+@Component
+@ConfigurationProperties(prefix = "archipelobby.discord.bot-login")
+class BotLoginProperties {
+    var baseUrl: String = "http://localhost:8080"
+    var tokenValidity: Duration = Duration.ofMinutes(5)
+}
+
+@Service
+class BotLoginService(
+    private val discordService: DiscordService,
+    private val properties: BotLoginProperties,
+    private val clock: Clock = Clock.systemUTC(),
+    private val tokenGenerator: () -> String = DEFAULT_TOKEN_GENERATOR
+) {
+    private data class PendingLogin(val principal: DiscordPrincipal, val expiresAt: Instant)
+
+    private val pendingLogins = ConcurrentHashMap<String, PendingLogin>()
+
+    suspend fun createLoginLink(userId: Long): String? {
+        if (!discordService.isMemberOfAnyGuild(userId)) return null
+
+        val user = discordService.getUserInfo(userId)
+        val now = clock.instant()
+        pendingLogins.entries.removeIf { it.value.expiresAt <= now }
+
+        val pendingLogin = PendingLogin(
+            DiscordPrincipal(user.id, user.username),
+            now.plus(properties.tokenValidity)
+        )
+        val token = storeWithUniqueToken(pendingLogin)
+        return "${properties.baseUrl.trimEnd('/')}/login/bot?token=$token"
+    }
+
+    fun consume(token: String): DiscordPrincipal? {
+        val pendingLogin = pendingLogins.remove(token) ?: return null
+        return pendingLogin.principal.takeIf { pendingLogin.expiresAt > clock.instant() }
+    }
+
+    private fun storeWithUniqueToken(pendingLogin: PendingLogin): String {
+        repeat(10) {
+            val token = tokenGenerator()
+            if (pendingLogins.putIfAbsent(token, pendingLogin) == null) return token
+        }
+        throw IllegalStateException("Could not generate a unique bot login token")
+    }
+
+    companion object {
+        private val SECURE_RANDOM = SecureRandom()
+        private val DEFAULT_TOKEN_GENERATOR = {
+            ByteArray(32).also(SECURE_RANDOM::nextBytes).let {
+                Base64.getUrlEncoder().withoutPadding().encodeToString(it)
+            }
+        }
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -12,6 +12,10 @@ spring.security.oauth2.client.provider.discord.token-uri=https://discord.com/api
 spring.security.oauth2.client.provider.discord.user-info-uri=https://discord.com/api/users/@me
 spring.security.oauth2.client.provider.discord.user-name-attribute=id
 
+# Public origin included in one-time login links returned by the Discord bot.
+archipelobby.discord.bot-login.base-url=${ARCHIPELOBBY_BASE_URL:http://localhost:8080}
+archipelobby.discord.bot-login.token-validity=5m
+
 archipelobby.multiserver.enabled=true
 archipelobby.multiserver.port-range-start=38281
 archipelobby.multiserver.port-range-end=38380

--- a/src/test/kotlin/com/github/derminator/archipelobby/WebTests.kt
+++ b/src/test/kotlin/com/github/derminator/archipelobby/WebTests.kt
@@ -9,6 +9,7 @@ import com.github.derminator.archipelobby.generator.GameCatalogService
 import com.github.derminator.archipelobby.multiserver.InternalToken
 import com.github.derminator.archipelobby.multiserver.MultiServerManager
 import com.github.derminator.archipelobby.security.DiscordPrincipal
+import com.github.derminator.archipelobby.security.BotLoginService
 import com.github.derminator.archipelobby.storage.UploadsService
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flowOf
@@ -88,6 +89,9 @@ class WebTests {
 
     @Autowired
     lateinit var context: ApplicationContext
+
+    @Autowired
+    lateinit var botLoginService: BotLoginService
 
     lateinit var webTestClient: WebTestClient
 
@@ -413,6 +417,40 @@ class WebTests {
             .cookie(sessionCookie.name, sessionCookie.value)
             .exchange()
             .expectStatus().isOk
+    }
+
+    @Test
+    fun `bot login link establishes an authenticated session`() = runBlocking {
+        `when`(discordService.getUserInfo(0L)).thenReturn(UserInfo(0L, "bot-user"))
+        val link = requireNotNull(botLoginService.createLoginLink(0L))
+        val token = link.substringAfter("token=")
+
+        val loginResult = webTestClient.get().uri { builder ->
+            builder.path("/login/bot").queryParam("token", token).build()
+        }
+            .exchange()
+            .expectStatus().is3xxRedirection
+            .expectHeader().valueEquals("Location", "/rooms")
+            .expectBody<String>().returnResult()
+        val sessionCookie = loginResult.responseCookies.values.flatten().single()
+
+        webTestClient.get().uri("/rooms")
+            .cookie(sessionCookie.name, sessionCookie.value)
+            .exchange()
+            .expectStatus().isOk
+
+        webTestClient.get().uri { builder ->
+            builder.path("/login/bot").queryParam("token", token).build()
+        }
+            .exchange()
+            .expectStatus().isUnauthorized
+    }
+
+    @Test
+    fun `invalid bot login link is rejected without authentication`() {
+        webTestClient.get().uri("/login/bot?token=invalid")
+            .exchange()
+            .expectStatus().isUnauthorized
     }
 
     @Test

--- a/src/test/kotlin/com/github/derminator/archipelobby/discord/DiscordLoginBotTest.kt
+++ b/src/test/kotlin/com/github/derminator/archipelobby/discord/DiscordLoginBotTest.kt
@@ -1,0 +1,59 @@
+package com.github.derminator.archipelobby.discord
+
+import com.github.derminator.archipelobby.security.BotLoginService
+import discord4j.core.GatewayDiscordClient
+import discord4j.core.event.domain.interaction.ChatInputInteractionEvent
+import discord4j.core.event.domain.message.MessageCreateEvent
+import discord4j.core.`object`.entity.Message
+import discord4j.core.`object`.entity.User
+import discord4j.core.`object`.entity.channel.MessageChannel
+import discord4j.common.util.Snowflake
+import discord4j.discordjson.json.ApplicationCommandRequest
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import org.mockito.ArgumentMatchers.any
+import org.mockito.ArgumentMatchers.eq
+import org.mockito.Mockito.RETURNS_DEEP_STUBS
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.timeout
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when` as whenever
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+import java.util.Optional
+
+class DiscordLoginBotTest {
+
+    @Test
+    fun `responds to login direct message with private login link`() {
+        val gateway = mock(GatewayDiscordClient::class.java, RETURNS_DEEP_STUBS)
+        val event = mock(MessageCreateEvent::class.java)
+        val message = mock(Message::class.java)
+        val user = mock(User::class.java)
+        val channel = mock(MessageChannel::class.java, RETURNS_DEEP_STUBS)
+        val botLoginService = mock(BotLoginService::class.java)
+        val link = "https://lobby.example.com/login/bot?token=generated-token"
+
+        whenever(gateway.restClient.applicationId).thenReturn(Mono.just(1L))
+        whenever(
+            gateway.restClient.applicationService.createGlobalApplicationCommand(
+                eq(1L),
+                any(ApplicationCommandRequest::class.java)
+            )
+        ).thenReturn(Mono.empty())
+        whenever(gateway.on(ChatInputInteractionEvent::class.java)).thenReturn(Flux.never())
+        whenever(gateway.on(MessageCreateEvent::class.java)).thenReturn(Flux.just(event))
+        whenever(event.guildId).thenReturn(Optional.empty())
+        whenever(event.message).thenReturn(message)
+        whenever(message.content).thenReturn(" /LOGIN ")
+        whenever(message.author).thenReturn(Optional.of(user))
+        whenever(message.channel).thenReturn(Mono.just(channel))
+        whenever(user.isBot).thenReturn(false)
+        whenever(user.id).thenReturn(Snowflake.of(42L))
+        runBlocking { whenever(botLoginService.createLoginLink(42L)).thenReturn(link) }
+        val bot = DiscordLoginBot(gateway, botLoginService)
+
+        verify(channel, timeout(1_000)).createMessage("Use this one-time link to log in: $link")
+        bot.stop()
+    }
+}

--- a/src/test/kotlin/com/github/derminator/archipelobby/security/BotLoginServiceTest.kt
+++ b/src/test/kotlin/com/github/derminator/archipelobby/security/BotLoginServiceTest.kt
@@ -1,0 +1,69 @@
+package com.github.derminator.archipelobby.security
+
+import com.github.derminator.archipelobby.discord.DiscordService
+import com.github.derminator.archipelobby.discord.UserInfo
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneOffset
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class BotLoginServiceTest {
+    private val discordService = mock(DiscordService::class.java)
+    private val properties = BotLoginProperties().apply {
+        baseUrl = "https://lobby.example.com/"
+        tokenValidity = Duration.ofMinutes(5)
+    }
+    private val now = Instant.parse("2026-07-31T12:00:00Z")
+
+    @Test
+    fun `creates a one-time login for a server member`() = runBlocking {
+        `when`(discordService.isMemberOfAnyGuild(42L)).thenReturn(true)
+        `when`(discordService.getUserInfo(42L)).thenReturn(UserInfo(42L, "player"))
+        val service = service(token = "generated-token")
+
+        val link = service.createLoginLink(42L)
+
+        assertEquals("https://lobby.example.com/login/bot?token=generated-token", link)
+        assertEquals(DiscordPrincipal(42L, "player"), service.consume("generated-token"))
+        assertNull(service.consume("generated-token"))
+    }
+
+    @Test
+    fun `does not create a login for a non-member`() = runBlocking {
+        `when`(discordService.isMemberOfAnyGuild(42L)).thenReturn(false)
+        val service = service()
+
+        assertNull(service.createLoginLink(42L))
+        verify(discordService).isMemberOfAnyGuild(42L)
+        verifyNoInteractionsAfterMembershipCheck()
+    }
+
+    @Test
+    fun `expired login cannot be consumed`() = runBlocking {
+        properties.tokenValidity = Duration.ZERO
+        `when`(discordService.isMemberOfAnyGuild(42L)).thenReturn(true)
+        `when`(discordService.getUserInfo(42L)).thenReturn(UserInfo(42L, "player"))
+        val service = service()
+
+        service.createLoginLink(42L)
+
+        assertNull(service.consume("token"))
+    }
+
+    private fun service(token: String = "token") = BotLoginService(
+        discordService,
+        properties,
+        Clock.fixed(now, ZoneOffset.UTC)
+    ) { token }
+
+    private suspend fun verifyNoInteractionsAfterMembershipCheck() {
+        verify(discordService, org.mockito.Mockito.never()).getUserInfo(42L)
+    }
+}


### PR DESCRIPTION
Closes #84

## Summary

Adds an alternative Discord bot login flow that issues private, one-time magic links to verified server members.

- Registers a global `/login` command and supports `/login` via bot DM.
- Verifies the requester belongs to a guild shared with the bot before generating a link.
- Adds `GET /login/bot?token=...`, which consumes the token, establishes a session, rotates the session ID, and redirects to `/rooms`.
- Uses cryptographically secure 32-byte URL-safe tokens, stored in memory, with a five-minute expiration and single-use consumption.
- Prevents login-link caching and referrer token leakage with `Cache-Control: no-store` and `Referrer-Policy: no-referrer`.
- Adds `ARCHIPELOBBY_BASE_URL` configuration and documents bot-login setup and usage.

## Tests

Adds coverage for valid, invalid, expired, and reused login links, authenticated session creation, non-member rejection, and bot DM login responses.

_Implemented by ai-harness._