### PR TITLE
Add ports for servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,9 +123,11 @@ docker build -t archipelobby .
 
 # Run the container
 docker run -p 8080:8080 \
+  -p 38281-38380:38281-38380 \
   -e DISCORD_CLIENT_ID=your_client_id \
   -e DISCORD_CLIENT_SECRET=your_client_secret \
   -e DISCORD_BOT_TOKEN=your_bot_token \
+  -e ARCHIPELOBBY_MULTISERVER_PUBLIC_HOST=games.example.com \
   -v /path/to/data:/data \
   archipelobby
 ```
@@ -137,8 +139,45 @@ application restart.
 
 The application will be available at `http://localhost:8080`
 
+Each running room also receives a port in the configured `38281-38380` range.
+The room page shows both `ws://games.example.com:<port>` for clients that only
+support the WebSocket root path and the existing `/rooms/<id>/ws` proxy URL.
+Publish the whole range and allow it through the host firewall to support direct
+connections. Set `ARCHIPELOBBY_MULTISERVER_PUBLIC_HOST` to the externally
+resolvable hostname; when it is unset, the application uses the room page's
+request hostname.
+
 The Docker build installs Archipelago's pinned Python dependencies into the
 image. This avoids an interactive dependency prompt when opening a room.
+
+### k3s and Cloudflare hostname-routing plan
+
+Cloudflare's normal proxied DNS does not forward arbitrary ports such as
+`38281-38380`, so direct port addresses must initially use a DNS-only record (or
+Cloudflare Spectrum) and a k3s `LoadBalancer`/`NodePort` service that publishes
+the configured range. Keep a single application replica while MultiServers are
+child processes local to the application pod.
+
+The preferred Cloudflare-compatible follow-up is hostname matching over port
+443, which preserves a root WebSocket path for limited clients:
+
+1. Add a root-path WebSocket handler that accepts only a configured wildcard
+   suffix, for example `room-123.ap.example.com`, extracts room `123` from the
+   normalized `Host`, and proxies to that room's live allocated port. Reject
+   unknown hosts and do not use an untrusted host as an upstream address.
+2. Point `*.ap.example.com` through a Cloudflare Tunnel to one k3s service on
+   the application's port `8080`. The service does not need to expose every
+   MultiServer port because Spring and its child processes share the pod
+   network namespace.
+3. Configure the application to trust forwarded headers only from the local
+   ingress or `cloudflared`, and advertise `wss://room-<id>.ap.example.com` on
+   room pages. Retain the direct-port and `/rooms/<id>/ws` addresses during the
+   rollout.
+4. Run an end-to-end check on a k3s test cluster: start two rooms, verify their
+   hostnames reach different saves through `/`, reconnect each client, stop one
+   room and confirm only its hostname closes, and verify an invalid hostname is
+   rejected. Repeat through the Cloudflare edge to confirm wildcard TLS,
+   WebSocket upgrades, forwarded hosts, and idle reconnect behavior.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -145,7 +145,8 @@ support the WebSocket root path and the existing `/rooms/<id>/ws` proxy URL.
 Publish the whole range and allow it through the host firewall to support direct
 connections. Set `ARCHIPELOBBY_MULTISERVER_PUBLIC_HOST` to the externally
 resolvable hostname; when it is unset, the application uses the room page's
-request hostname.
+request hostname. A newly launched room is shown as `Starting`, and neither
+address is advertised until its MultiServer listener accepts TCP connections.
 
 The Docker build installs Archipelago's pinned Python dependencies into the
 image. This avoids an interactive dependency prompt when opening a room.
@@ -154,9 +155,40 @@ image. This avoids an interactive dependency prompt when opening a room.
 
 Cloudflare's normal proxied DNS does not forward arbitrary ports such as
 `38281-38380`, so direct port addresses must initially use a DNS-only record (or
-Cloudflare Spectrum) and a k3s `LoadBalancer`/`NodePort` service that publishes
-the configured range. Keep a single application replica while MultiServers are
-child processes local to the application pod.
+Cloudflare Spectrum). In k3s, prefer a TCP-capable `LoadBalancer` implementation
+such as MetalLB that can publish these ports. Kubernetes does not support a port
+range in a Service: declare all 100 entries, each with the same `port` and
+`targetPort`, and select the single Archipelobby pod. For example, the list must
+start and end like this (generate the intervening entries in deployment
+configuration):
+
+```yaml
+spec:
+  type: LoadBalancer
+  ports:
+    - name: multiserver-38281
+      protocol: TCP
+      port: 38281
+      targetPort: 38281
+    - name: multiserver-38282
+      protocol: TCP
+      port: 38282
+      targetPort: 38282
+    # One entry for every port through 38379.
+    - name: multiserver-38380
+      protocol: TCP
+      port: 38380
+      targetPort: 38380
+```
+
+If NodePort is required instead, the default Kubernetes range
+`30000-32767` cannot allocate `38281-38380`. Configure every k3s server with
+`service-node-port-range: "30000-38380"` in
+`/etc/rancher/k3s/config.yaml`, restart k3s, and declare every Service entry
+shown above with `nodePort` equal to its room port. Ensure the node firewall and
+upstream router expose that range. Do not deploy this Service on an unmodified
+k3s cluster. Keep a single application replica while MultiServers are child
+processes local to the application pod.
 
 The preferred Cloudflare-compatible follow-up is hostname matching over port
 443, which preserves a root WebSocket path for limited clients:

--- a/README.md
+++ b/README.md
@@ -146,7 +146,8 @@ Publish the whole range and allow it through the host firewall to support direct
 connections. Set `ARCHIPELOBBY_MULTISERVER_PUBLIC_HOST` to the externally
 resolvable hostname; when it is unset, the application uses the room page's
 request hostname. A newly launched room is shown as `Starting`, and neither
-address is advertised until its MultiServer listener accepts TCP connections.
+address is advertised until that room's MultiServer confirms that it bound its
+listener. Ports already occupied by another process are skipped.
 
 The Docker build installs Archipelago's pinned Python dependencies into the
 image. This avoids an interactive dependency prompt when opening a room.

--- a/python/multiserver_wrapper.py
+++ b/python/multiserver_wrapper.py
@@ -91,6 +91,23 @@ def install_save_hooks(base_url: str, token: str, room_id: int, multi_server) ->
     multi_server.Context.init_save = init_save
 
 
+def install_ready_hook(ready_token: str, multi_server) -> None:
+    """Report readiness only after this process successfully owns its port."""
+    original_serve = multi_server.websockets.serve
+
+    def serve(*args, **kwargs):
+        server_awaitable = original_serve(*args, **kwargs)
+
+        async def start_server():
+            server = await server_awaitable
+            print(f"ARCHIPELOBBY_READY={ready_token}", flush=True)
+            return server
+
+        return start_server()
+
+    multi_server.websockets.serve = serve
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(allow_abbrev=False)
     parser.add_argument("--spring-url", required=True)
@@ -102,6 +119,10 @@ def main() -> None:
     token = os.environ.get("ARCHIPELOBBY_SPRING_TOKEN")
     if not token:
         print("ARCHIPELOBBY_SPRING_TOKEN env var is required", file=sys.stderr)
+        sys.exit(1)
+    ready_token = os.environ.get("ARCHIPELOBBY_READY_TOKEN")
+    if not ready_token:
+        print("ARCHIPELOBBY_READY_TOKEN env var is required", file=sys.stderr)
         sys.exit(1)
 
     sys.path.insert(0, os.path.abspath(args.archipelago_dir))
@@ -120,6 +141,7 @@ def main() -> None:
 
     import MultiServer
     install_save_hooks(args.spring_url, token, args.room_id, MultiServer)
+    install_ready_hook(ready_token, MultiServer)
 
     # MultiServer defines the multidata file as its optional positional
     # argument, not as a --multidata option.

--- a/python/test_multiserver_wrapper.py
+++ b/python/test_multiserver_wrapper.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 import sys
 import types
@@ -39,12 +40,16 @@ class MultiServerWrapperTest(unittest.TestCase):
         with (
             patch.object(sys, "argv", wrapper_argv),
             patch.object(sys, "path", sys.path.copy()),
-            patch.dict(os.environ, {"ARCHIPELOBBY_SPRING_TOKEN": "test-token"}),
+            patch.dict(os.environ, {
+                "ARCHIPELOBBY_SPRING_TOKEN": "test-token",
+                "ARCHIPELOBBY_READY_TOKEN": "ready-token",
+            }),
             patch.dict(sys.modules, {"MultiServer": multi_server}),
             patch.object(multiserver_wrapper.tempfile, "mkdtemp", return_value="/tmp/archipelobby-test"),
             patch.object(multiserver_wrapper.atexit, "register"),
             patch.object(multiserver_wrapper, "fetch_game_data"),
             patch.object(multiserver_wrapper, "install_save_hooks"),
+            patch.object(multiserver_wrapper, "install_ready_hook") as install_ready_hook,
         ):
             multiserver_wrapper.main()
 
@@ -58,6 +63,26 @@ class MultiServerWrapperTest(unittest.TestCase):
             ],
         )
         self.assertIs(main_args, parsed_args)
+        install_ready_hook.assert_called_once_with("ready-token", multi_server)
+
+    def test_reports_ready_only_after_server_bind_completes(self):
+        events = []
+
+        async def serve(*_, **__):
+            events.append("bound")
+            return "server"
+
+        multi_server = types.SimpleNamespace(
+            websockets=types.SimpleNamespace(serve=serve),
+        )
+        multiserver_wrapper.install_ready_hook("unique-token", multi_server)
+
+        with patch("builtins.print") as output:
+            server = asyncio.run(multi_server.websockets.serve())
+
+        self.assertEqual(server, "server")
+        self.assertEqual(events, ["bound"])
+        output.assert_called_once_with("ARCHIPELOBBY_READY=unique-token", flush=True)
 
 
 if __name__ == "__main__":

--- a/src/main/kotlin/com/github/derminator/archipelobby/controllers/RoomController.kt
+++ b/src/main/kotlin/com/github/derminator/archipelobby/controllers/RoomController.kt
@@ -480,9 +480,8 @@ class RoomController(
         model.addAttribute("apWorlds", roomService.getApWorldsForRoom(roomId, userId).toList())
         model.addAttribute("roomGames", roomWithEntries.roomGames)
         model.addAttribute("pun", Puns.forRoom(roomId))
-        // Fetching the port also checks that the process is still alive, avoiding
-        // a running-state/port lookup race while rendering connection details.
         val serverPort = roomService.getServerPort(roomId)
+        val serverRunning = serverPort != null || roomService.isServerRunning(roomId)
         val proxyServerAddress = if (serverPort != null) {
             val uri = exchange.request.uri
             val host = uri.host + if (uri.port > 0) ":${uri.port}" else ""
@@ -497,6 +496,7 @@ class RoomController(
         }
         model.addAttribute("proxyServerAddress", proxyServerAddress)
         model.addAttribute("directServerAddress", directServerAddress)
+        model.addAttribute("serverRunning", serverRunning)
     }
 
     private suspend fun readFilePart(filePart: FilePart): ByteArray {

--- a/src/main/kotlin/com/github/derminator/archipelobby/controllers/RoomController.kt
+++ b/src/main/kotlin/com/github/derminator/archipelobby/controllers/RoomController.kt
@@ -5,6 +5,7 @@ import com.github.derminator.archipelobby.data.EntryYaml
 import com.github.derminator.archipelobby.data.Puns
 import com.github.derminator.archipelobby.data.RoomService
 import com.github.derminator.archipelobby.generator.GameCatalogService
+import com.github.derminator.archipelobby.multiserver.MultiServerProperties
 import com.github.derminator.archipelobby.security.asDiscordPrincipal
 import com.github.derminator.archipelobby.storage.UploadsService
 import kotlinx.coroutines.Dispatchers
@@ -38,6 +39,7 @@ class RoomController(
     private val roomService: RoomService,
     private val uploadsService: UploadsService,
     private val gameCatalogService: GameCatalogService,
+    private val multiServerProperties: MultiServerProperties,
 ) {
     private val yamlMapper = YAMLMapper.builder()
         .addModule(KotlinModule.Builder().build())
@@ -478,9 +480,10 @@ class RoomController(
         model.addAttribute("apWorlds", roomService.getApWorldsForRoom(roomId, userId).toList())
         model.addAttribute("roomGames", roomWithEntries.roomGames)
         model.addAttribute("pun", Puns.forRoom(roomId))
-        // Full WebSocket connect address when the server is running, otherwise null.
-        // The UI derives the running/stopped state from whether this is present.
-        val serverAddress = if (roomService.isServerRunning(roomId)) {
+        // Fetching the port also checks that the process is still alive, avoiding
+        // a running-state/port lookup race while rendering connection details.
+        val serverPort = roomService.getServerPort(roomId)
+        val proxyServerAddress = if (serverPort != null) {
             val uri = exchange.request.uri
             val host = uri.host + if (uri.port > 0) ":${uri.port}" else ""
             val scheme = if (uri.scheme == "https") "wss" else "ws"
@@ -488,7 +491,12 @@ class RoomController(
         } else {
             null
         }
-        model.addAttribute("serverAddress", serverAddress)
+        val directServerAddress = serverPort?.let {
+            val publicHost = multiServerProperties.publicHost.ifBlank { exchange.request.uri.host }
+            "ws://${hostForUrl(publicHost)}:$it"
+        }
+        model.addAttribute("proxyServerAddress", proxyServerAddress)
+        model.addAttribute("directServerAddress", directServerAddress)
     }
 
     private suspend fun readFilePart(filePart: FilePart): ByteArray {
@@ -501,4 +509,7 @@ class RoomController(
         }
         return outputStream.toByteArray()
     }
+
+    private fun hostForUrl(host: String): String =
+        if (':' in host && !host.startsWith('[')) "[$host]" else host
 }

--- a/src/main/kotlin/com/github/derminator/archipelobby/data/RoomService.kt
+++ b/src/main/kotlin/com/github/derminator/archipelobby/data/RoomService.kt
@@ -583,6 +583,8 @@ class RoomService(
 
     fun getServerPort(roomId: Long): Int? = multiServerManager.getServerPort(roomId)
 
+    fun isServerRunning(roomId: Long): Boolean = multiServerManager.isRunning(roomId)
+
     suspend fun getRoomForPreview(roomId: Long): RoomPreview {
         val room = roomRepository.findById(roomId).awaitSingleOrNull()
             ?: throw ResponseStatusException(HttpStatus.NOT_FOUND)

--- a/src/main/kotlin/com/github/derminator/archipelobby/data/RoomService.kt
+++ b/src/main/kotlin/com/github/derminator/archipelobby/data/RoomService.kt
@@ -581,7 +581,7 @@ class RoomService(
         multiServerManager.stopServer(roomId)
     }
 
-    fun isServerRunning(roomId: Long): Boolean = multiServerManager.isRunning(roomId)
+    fun getServerPort(roomId: Long): Int? = multiServerManager.getServerPort(roomId)
 
     suspend fun getRoomForPreview(roomId: Long): RoomPreview {
         val room = roomRepository.findById(roomId).awaitSingleOrNull()

--- a/src/main/kotlin/com/github/derminator/archipelobby/multiserver/MultiServerManager.kt
+++ b/src/main/kotlin/com/github/derminator/archipelobby/multiserver/MultiServerManager.kt
@@ -6,10 +6,9 @@ interface MultiServerManager {
     fun isRunning(roomId: Long): Boolean
 
     /**
-     * The port the room's MultiServer is listening on, or null when no server is
-     * running for the room. Only returns a port while the backing process is
-     * alive, so callers get an atomic check and don't need a separate
-     * [isRunning] call.
+     * The port the room's MultiServer is listening on, or null until its listener
+     * is ready or after the process exits. Callers can use [isRunning] separately
+     * when they need to distinguish a starting process from a stopped one.
      */
     fun getServerPort(roomId: Long): Int?
 }

--- a/src/main/kotlin/com/github/derminator/archipelobby/multiserver/MultiServerProperties.kt
+++ b/src/main/kotlin/com/github/derminator/archipelobby/multiserver/MultiServerProperties.kt
@@ -12,9 +12,9 @@ data class MultiServerProperties(
     val portRangeEnd: Int = 38380,
     // Address used by Spring when proxying to a MultiServer process.
     val host: String = "127.0.0.1",
-    // Address passed to MultiServer's --host option. Production binds all
-    // interfaces so the allocated ports can be published directly.
-    val bindHost: String = "127.0.0.1",
+    // Address passed to MultiServer's --host option. Inherit host to preserve
+    // the binding behavior of installations configured before this was split.
+    val bindHost: String = host,
     // Hostname shown to players for direct port connections. Blank derives it
     // from the room page request.
     val publicHost: String = "",

--- a/src/main/kotlin/com/github/derminator/archipelobby/multiserver/MultiServerProperties.kt
+++ b/src/main/kotlin/com/github/derminator/archipelobby/multiserver/MultiServerProperties.kt
@@ -10,7 +10,14 @@ data class MultiServerProperties(
     val enabled: Boolean = false,
     val portRangeStart: Int = 38281,
     val portRangeEnd: Int = 38380,
+    // Address used by Spring when proxying to a MultiServer process.
     val host: String = "127.0.0.1",
+    // Address passed to MultiServer's --host option. Production binds all
+    // interfaces so the allocated ports can be published directly.
+    val bindHost: String = "127.0.0.1",
+    // Hostname shown to players for direct port connections. Blank derives it
+    // from the room page request.
+    val publicHost: String = "",
     val scriptPath: String = "Archipelago/MultiServer.py",
     val wrapperScriptPath: String = "python/multiserver_wrapper.py",
     val internalBaseUrl: String = "http://localhost:8080",

--- a/src/main/kotlin/com/github/derminator/archipelobby/multiserver/ProcessMultiServerManager.kt
+++ b/src/main/kotlin/com/github/derminator/archipelobby/multiserver/ProcessMultiServerManager.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.reactive.asFlow
 import kotlinx.coroutines.reactor.awaitSingleOrNull
@@ -22,6 +23,8 @@ import org.springframework.web.server.ResponseStatusException
 import java.io.BufferedReader
 import java.io.File
 import java.io.InputStreamReader
+import java.net.InetSocketAddress
+import java.net.Socket
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.TimeUnit
 
@@ -42,7 +45,12 @@ class ProcessMultiServerManager(
     private val lifecycleScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     @Volatile private var running = false
 
-    private data class ManagedServer(val process: Process, val port: Int, val logThread: Thread)
+    private data class ManagedServer(
+        val process: Process,
+        val port: Int,
+        val logThread: Thread,
+        @Volatile var ready: Boolean = false,
+    )
 
     private fun lockFor(roomId: Long): Mutex = roomLocks.computeIfAbsent(roomId) { Mutex() }
 
@@ -110,6 +118,7 @@ class ProcessMultiServerManager(
                 managed = ManagedServer(process, port, logThread)
                 processes[roomId] = managed
                 logThread.start()
+                lifecycleScope.launch { awaitListener(roomId, managed) }
 
                 if (!process.isAlive) {
                     processes.remove(roomId, managed)
@@ -142,7 +151,23 @@ class ProcessMultiServerManager(
 
     override fun isRunning(roomId: Long): Boolean = aliveServer(roomId) != null
 
-    override fun getServerPort(roomId: Long): Int? = aliveServer(roomId)?.port
+    override fun getServerPort(roomId: Long): Int? = aliveServer(roomId)?.takeIf { it.ready }?.port
+
+    private suspend fun awaitListener(roomId: Long, managed: ManagedServer) {
+        while (managed.process.isAlive && processes[roomId] === managed) {
+            val listening = runCatching {
+                Socket().use { socket ->
+                    socket.connect(InetSocketAddress(properties.host, managed.port), READINESS_TIMEOUT_MILLIS)
+                }
+            }.isSuccess
+            if (listening) {
+                managed.ready = true
+                logger.info("MultiServer for room {} is accepting connections on port {}", roomId, managed.port)
+                return
+            }
+            delay(READINESS_POLL_MILLIS)
+        }
+    }
 
     /**
      * The room's managed server, but only while its process is alive. If the
@@ -216,4 +241,9 @@ class ProcessMultiServerManager(
     override fun isRunning(): Boolean = running
 
     override fun getPhase(): Int = Int.MAX_VALUE - 1
+
+    companion object {
+        private const val READINESS_POLL_MILLIS = 100L
+        private const val READINESS_TIMEOUT_MILLIS = 100
+    }
 }

--- a/src/main/kotlin/com/github/derminator/archipelobby/multiserver/ProcessMultiServerManager.kt
+++ b/src/main/kotlin/com/github/derminator/archipelobby/multiserver/ProcessMultiServerManager.kt
@@ -6,7 +6,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.reactive.asFlow
 import kotlinx.coroutines.reactor.awaitSingleOrNull
@@ -24,9 +23,10 @@ import java.io.BufferedReader
 import java.io.File
 import java.io.InputStreamReader
 import java.net.InetSocketAddress
-import java.net.Socket
+import java.net.ServerSocket
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.TimeUnit
+import java.util.UUID
 
 @Service
 @ConditionalOnProperty("archipelobby.multiserver.enabled", havingValue = "true")
@@ -49,6 +49,7 @@ class ProcessMultiServerManager(
         val process: Process,
         val port: Int,
         val logThread: Thread,
+        val readyToken: String,
         @Volatile var ready: Boolean = false,
     )
 
@@ -74,6 +75,9 @@ class ProcessMultiServerManager(
                 logger.info("Server for room {} is already running on port {}", roomId, existing.port)
                 return
             }
+            if (existing != null) {
+                processes.remove(roomId, existing)
+            }
 
             val room = roomRepository.findById(roomId).awaitSingleOrNull()
                 ?: throw IllegalArgumentException("Room $roomId not found")
@@ -85,10 +89,14 @@ class ProcessMultiServerManager(
             val port = allocatePort()
             try {
                 logger.info("Starting MultiServer for room {} on port {}", roomId, port)
+                val readyToken = UUID.randomUUID().toString()
 
                 val process = pythonScriptRunner.runInBackground(
                     scriptPath = properties.wrapperScriptPath,
-                    extraEnv = mapOf("ARCHIPELOBBY_SPRING_TOKEN" to internalToken.value),
+                    extraEnv = mapOf(
+                        "ARCHIPELOBBY_SPRING_TOKEN" to internalToken.value,
+                        "ARCHIPELOBBY_READY_TOKEN" to readyToken,
+                    ),
                     "--spring-url", properties.internalBaseUrl,
                     "--room-id", roomId.toString(),
                     "--archipelago-dir", archipelagoDir(),
@@ -101,7 +109,18 @@ class ProcessMultiServerManager(
                     BufferedReader(InputStreamReader(process.inputStream, Charsets.UTF_8)).use { reader ->
                         while (true) {
                             val line = reader.readLine() ?: break
-                            logger.info("[multiserver:{}] {}", roomId, line)
+                            if (line == "$READY_PREFIX$readyToken" &&
+                                process.isAlive && processes[roomId] === managed
+                            ) {
+                                managed.ready = true
+                                logger.info(
+                                    "MultiServer for room {} is accepting connections on port {}",
+                                    roomId,
+                                    port,
+                                )
+                            } else {
+                                logger.info("[multiserver:{}] {}", roomId, line)
+                            }
                         }
                     }
                     val exitCode = process.waitFor()
@@ -115,10 +134,9 @@ class ProcessMultiServerManager(
                     }
                 }, "multiserver-log-$roomId").apply { isDaemon = true }
 
-                managed = ManagedServer(process, port, logThread)
+                managed = ManagedServer(process, port, logThread, readyToken)
                 processes[roomId] = managed
                 logThread.start()
-                lifecycleScope.launch { awaitListener(roomId, managed) }
 
                 if (!process.isAlive) {
                     processes.remove(roomId, managed)
@@ -134,8 +152,11 @@ class ProcessMultiServerManager(
 
     override suspend fun stopServer(roomId: Long) {
         lockFor(roomId).withLock {
-            val managed = processes.remove(roomId) ?: return
-            if (!managed.process.isAlive) return
+            val managed = processes[roomId] ?: return
+            if (!managed.process.isAlive) {
+                processes.remove(roomId, managed)
+                return
+            }
 
             logger.info("Stopping MultiServer for room {} (port {})", roomId, managed.port)
             managed.process.destroy()
@@ -145,6 +166,12 @@ class ProcessMultiServerManager(
             if (!stopped) {
                 logger.warn("MultiServer for room {} did not stop gracefully, forcing", roomId)
                 managed.process.destroyForcibly()
+                val forced = withContext(Dispatchers.IO) {
+                    managed.process.waitFor(10, TimeUnit.SECONDS)
+                }
+                if (!forced) {
+                    logger.error("MultiServer for room {} did not exit after being forced", roomId)
+                }
             }
         }
     }
@@ -152,22 +179,6 @@ class ProcessMultiServerManager(
     override fun isRunning(roomId: Long): Boolean = aliveServer(roomId) != null
 
     override fun getServerPort(roomId: Long): Int? = aliveServer(roomId)?.takeIf { it.ready }?.port
-
-    private suspend fun awaitListener(roomId: Long, managed: ManagedServer) {
-        while (managed.process.isAlive && processes[roomId] === managed) {
-            val listening = runCatching {
-                Socket().use { socket ->
-                    socket.connect(InetSocketAddress(properties.host, managed.port), READINESS_TIMEOUT_MILLIS)
-                }
-            }.isSuccess
-            if (listening) {
-                managed.ready = true
-                logger.info("MultiServer for room {} is accepting connections on port {}", roomId, managed.port)
-                return
-            }
-            delay(READINESS_POLL_MILLIS)
-        }
-    }
 
     /**
      * The room's managed server, but only while its process is alive. If the
@@ -187,13 +198,22 @@ class ProcessMultiServerManager(
     private suspend fun allocatePort(): Int = allocationMutex.withLock {
         val usedPorts = processes.values.mapTo(mutableSetOf()) { it.port }
         usedPorts.addAll(pendingPorts)
-        val port = (properties.portRangeStart..properties.portRangeEnd).firstOrNull { it !in usedPorts }
+        val port = (properties.portRangeStart..properties.portRangeEnd).firstOrNull {
+            it !in usedPorts && canBind(it)
+        }
             ?: error("No available ports in range ${properties.portRangeStart}-${properties.portRangeEnd}")
         // Reserve the port so a concurrent allocation for a different room doesn't
         // pick it before this caller can put a ManagedServer in `processes`.
         pendingPorts.add(port)
         port
     }
+
+    private fun canBind(port: Int): Boolean = runCatching {
+        ServerSocket().use { socket ->
+            socket.reuseAddress = false
+            socket.bind(InetSocketAddress(properties.bindHost, port))
+        }
+    }.isSuccess
 
     // SmartLifecycle
 
@@ -243,7 +263,6 @@ class ProcessMultiServerManager(
     override fun getPhase(): Int = Int.MAX_VALUE - 1
 
     companion object {
-        private const val READINESS_POLL_MILLIS = 100L
-        private const val READINESS_TIMEOUT_MILLIS = 100
+        private const val READY_PREFIX = "ARCHIPELOBBY_READY="
     }
 }

--- a/src/main/kotlin/com/github/derminator/archipelobby/multiserver/ProcessMultiServerManager.kt
+++ b/src/main/kotlin/com/github/derminator/archipelobby/multiserver/ProcessMultiServerManager.kt
@@ -85,7 +85,7 @@ class ProcessMultiServerManager(
                     "--room-id", roomId.toString(),
                     "--archipelago-dir", archipelagoDir(),
                     "--port", port.toString(),
-                    "--host", properties.host,
+                    "--host", properties.bindHost,
                 )
 
                 lateinit var managed: ManagedServer

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -6,6 +6,10 @@ spring.flyway.url=jdbc:h2:file:${app.data-dir}/archipelobby
 server.forward-headers-strategy=native
 server.reactive.session.cookie.secure=true
 archipelobby.multiserver.enabled=true
+# MultiServer ports are player-facing in production. Keep `host` on loopback:
+# Spring uses it for the optional path-based WebSocket proxy.
+archipelobby.multiserver.bind-host=0.0.0.0
+archipelobby.multiserver.public-host=${ARCHIPELOBBY_MULTISERVER_PUBLIC_HOST:}
 # The internal wrapper<->Spring token is generated on startup by default. Set
 # ARCHIPELOBBY_MULTISERVER_TOKEN when wrappers can outlive this process or when
 # multiple application instances need to share the same token.

--- a/src/main/resources/templates/room.html
+++ b/src/main/resources/templates/room.html
@@ -36,21 +36,23 @@
         </a>
 
         <h3>Server</h3>
-        <p th:if="${serverAddress != null}">
+        <p th:if="${directServerAddress != null}">
             Status: <strong>Running</strong>
-            <br/>Connect at:
-            <code th:text="${serverAddress}">ws://localhost/rooms/1/ws</code>
+            <br/>Connect directly (no subpath):
+            <code th:text="${directServerAddress}">ws://localhost:38281</code>
+            <br/>Proxy address:
+            <code th:text="${proxyServerAddress}">ws://localhost/rooms/1/ws</code>
         </p>
-        <p th:if="${serverAddress == null}">
+        <p th:if="${directServerAddress == null}">
             Status: <strong>Stopped</strong>
         </p>
         <div th:if="${isAdmin}" class="button-row">
-            <form th:if="${serverAddress == null}" method="post"
+            <form th:if="${directServerAddress == null}" method="post"
                   class="inline-form"
                   th:action="@{/rooms/{id}/server/start(id=${room.id})}">
                 <input type="submit" value="Start Server"/>
             </form>
-            <form th:if="${serverAddress != null}" method="post"
+            <form th:if="${directServerAddress != null}" method="post"
                   class="inline-form"
                   th:action="@{/rooms/{id}/server/stop(id=${room.id})}"
                   th:attr="data-confirm='Stop the server? Connected players will be disconnected.'">

--- a/src/main/resources/templates/room.html
+++ b/src/main/resources/templates/room.html
@@ -43,16 +43,19 @@
             <br/>Proxy address:
             <code th:text="${proxyServerAddress}">ws://localhost/rooms/1/ws</code>
         </p>
-        <p th:if="${directServerAddress == null}">
+        <p th:if="${directServerAddress == null and serverRunning}">
+            Status: <strong>Starting</strong>
+        </p>
+        <p th:if="${not serverRunning}">
             Status: <strong>Stopped</strong>
         </p>
         <div th:if="${isAdmin}" class="button-row">
-            <form th:if="${directServerAddress == null}" method="post"
+            <form th:if="${not serverRunning}" method="post"
                   class="inline-form"
                   th:action="@{/rooms/{id}/server/start(id=${room.id})}">
                 <input type="submit" value="Start Server"/>
             </form>
-            <form th:if="${directServerAddress != null}" method="post"
+            <form th:if="${serverRunning}" method="post"
                   class="inline-form"
                   th:action="@{/rooms/{id}/server/stop(id=${room.id})}"
                   th:attr="data-confirm='Stop the server? Connected players will be disconnected.'">

--- a/src/test/kotlin/com/github/derminator/archipelobby/WebTests.kt
+++ b/src/test/kotlin/com/github/derminator/archipelobby/WebTests.kt
@@ -1155,6 +1155,38 @@ class WebTests {
     }
 
     @Test
+    fun `room page shows starting status without advertising an unready port`(): Unit = runBlocking {
+        val roomId = 1L
+        val room = Room(
+            roomId, 123, "Test Room",
+            generatedGameFilePath = "path/to/game.archipelago",
+        )
+        `when`(roomRepository.findById(roomId)).thenReturn(Mono.just(room))
+        `when`(discordService.isMemberOfGuild(0L, 123)).thenReturn(true)
+        `when`(discordService.isAdminOfGuild(0L, 123)).thenReturn(true)
+        `when`(entryRepository.findByRoomId(roomId)).thenReturn(Flux.empty())
+        `when`(multiServerManager.getServerPort(roomId)).thenReturn(null)
+        `when`(multiServerManager.isRunning(roomId)).thenReturn(true)
+
+        webTestClient.mutateWith(
+            mockAuthentication(
+                UsernamePasswordAuthenticationToken(testPrincipal, null, listOf(SimpleGrantedAuthority("ROLE_USER")))
+            )
+        )
+            .get().uri("/rooms/$roomId")
+            .exchange()
+            .expectStatus().isOk
+            .expectBody<String>().consumeWith { response ->
+                val body = response.responseBody!!
+                assert(body.contains("Starting"))
+                assert(!body.contains("Connect directly"))
+                assert(!body.contains("/rooms/$roomId/ws"))
+                assert(body.contains("Stop Server"))
+                assert(!body.contains("Start Server"))
+            }
+    }
+
+    @Test
     fun `room page shows start button for admin when server stopped`(): Unit = runBlocking {
         val roomId = 1L
         val room = Room(

--- a/src/test/kotlin/com/github/derminator/archipelobby/WebTests.kt
+++ b/src/test/kotlin/com/github/derminator/archipelobby/WebTests.kt
@@ -45,7 +45,7 @@ import java.io.ByteArrayOutputStream
 import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
 
-@SpringBootTest
+@SpringBootTest(properties = ["archipelobby.multiserver.public-host=play.example.test"])
 @EnableAutoConfiguration(
     exclude = [
         R2dbcAutoConfiguration::class,
@@ -1108,7 +1108,7 @@ class WebTests {
         `when`(discordService.isMemberOfGuild(0L, 123)).thenReturn(true)
         `when`(discordService.isAdminOfGuild(0L, 123)).thenReturn(false)
         `when`(entryRepository.findByRoomId(roomId)).thenReturn(Flux.empty())
-        `when`(multiServerManager.isRunning(roomId)).thenReturn(true)
+        `when`(multiServerManager.getServerPort(roomId)).thenReturn(38281)
 
         webTestClient.mutateWith(
             mockAuthentication(
@@ -1121,6 +1121,7 @@ class WebTests {
             .expectBody<String>().consumeWith { response ->
                 val body = response.responseBody!!
                 assert(body.contains("Running"))
+                assert(body.contains("ws://play.example.test:38281"))
                 assert(body.contains("/rooms/$roomId/ws"))
             }
     }
@@ -1136,7 +1137,7 @@ class WebTests {
         `when`(discordService.isMemberOfGuild(0L, 123)).thenReturn(true)
         `when`(discordService.isAdminOfGuild(0L, 123)).thenReturn(false)
         `when`(entryRepository.findByRoomId(roomId)).thenReturn(Flux.empty())
-        `when`(multiServerManager.isRunning(roomId)).thenReturn(false)
+        `when`(multiServerManager.getServerPort(roomId)).thenReturn(null)
 
         webTestClient.mutateWith(
             mockAuthentication(
@@ -1149,7 +1150,7 @@ class WebTests {
             .expectBody<String>().consumeWith { response ->
                 val body = response.responseBody!!
                 assert(body.contains("Stopped"))
-                assert(!body.contains("Connect at"))
+                assert(!body.contains("Connect directly"))
             }
     }
 
@@ -1164,7 +1165,7 @@ class WebTests {
         `when`(discordService.isMemberOfGuild(0L, 123)).thenReturn(true)
         `when`(discordService.isAdminOfGuild(0L, 123)).thenReturn(true)
         `when`(entryRepository.findByRoomId(roomId)).thenReturn(Flux.empty())
-        `when`(multiServerManager.isRunning(roomId)).thenReturn(false)
+        `when`(multiServerManager.getServerPort(roomId)).thenReturn(null)
 
         webTestClient.mutateWith(
             mockAuthentication(
@@ -1192,7 +1193,7 @@ class WebTests {
         `when`(discordService.isMemberOfGuild(0L, 123)).thenReturn(true)
         `when`(discordService.isAdminOfGuild(0L, 123)).thenReturn(true)
         `when`(entryRepository.findByRoomId(roomId)).thenReturn(Flux.empty())
-        `when`(multiServerManager.isRunning(roomId)).thenReturn(true)
+        `when`(multiServerManager.getServerPort(roomId)).thenReturn(38282)
 
         webTestClient.mutateWith(
             mockAuthentication(
@@ -1220,7 +1221,7 @@ class WebTests {
         `when`(discordService.isMemberOfGuild(0L, 123)).thenReturn(true)
         `when`(discordService.isAdminOfGuild(0L, 123)).thenReturn(false)
         `when`(entryRepository.findByRoomId(roomId)).thenReturn(Flux.empty())
-        `when`(multiServerManager.isRunning(roomId)).thenReturn(true)
+        `when`(multiServerManager.getServerPort(roomId)).thenReturn(38283)
 
         webTestClient.mutateWith(
             mockAuthentication(
@@ -1233,6 +1234,7 @@ class WebTests {
             .expectBody<String>().consumeWith { response ->
                 val body = response.responseBody!!
                 assert(body.contains("Running"))
+                assert(body.contains("ws://play.example.test:38283"))
                 assert(body.contains("/rooms/$roomId/ws"))
                 assert(!body.contains("Start Server"))
                 assert(!body.contains("Stop Server"))

--- a/src/test/kotlin/com/github/derminator/archipelobby/multiserver/ProcessMultiServerManagerTest.kt
+++ b/src/test/kotlin/com/github/derminator/archipelobby/multiserver/ProcessMultiServerManagerTest.kt
@@ -1,0 +1,74 @@
+package com.github.derminator.archipelobby.multiserver
+
+import com.github.derminator.archipelobby.data.Room
+import com.github.derminator.archipelobby.data.RoomRepository
+import com.github.derminator.archipelobby.generator.PythonScriptRunner
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import reactor.core.publisher.Mono
+import java.net.ServerSocket
+import java.nio.file.Path
+import kotlin.io.path.writeText
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class ProcessMultiServerManagerTest {
+
+    @Test
+    fun `port is not published until the listener is ready`(@TempDir tempDir: Path) = runBlocking {
+        val port = ServerSocket(0).use { it.localPort }
+        val script = tempDir.resolve("delayed_server.py")
+        script.writeText(
+            """
+            import socket
+            import sys
+            import time
+
+            port = int(sys.argv[sys.argv.index("--port") + 1])
+            time.sleep(0.75)
+            with socket.socket() as server:
+                server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+                server.bind(("127.0.0.1", port))
+                server.listen()
+                time.sleep(10)
+            """.trimIndent(),
+        )
+        val roomRepository = mock(RoomRepository::class.java)
+        `when`(roomRepository.findById(1L)).thenReturn(
+            Mono.just(Room(1L, 123L, "Ready test", generatedGameFilePath = "game.archipelago")),
+        )
+        val properties = MultiServerProperties(
+            portRangeStart = port,
+            portRangeEnd = port,
+            host = "127.0.0.1",
+            scriptPath = tempDir.resolve("MultiServer.py").toString(),
+            wrapperScriptPath = script.toString(),
+        )
+        val manager = ProcessMultiServerManager(
+            properties,
+            roomRepository,
+            PythonScriptRunner("python3"),
+            InternalToken(properties),
+        )
+
+        try {
+            manager.startServer(1L)
+
+            assertTrue(manager.isRunning(1L))
+            assertNull(manager.getServerPort(1L))
+            val readyPort = withTimeout(5_000) {
+                while (manager.getServerPort(1L) == null) delay(25)
+                manager.getServerPort(1L)
+            }
+            assertEquals(port, readyPort)
+        } finally {
+            manager.stopServer(1L)
+        }
+    }
+}

--- a/src/test/kotlin/com/github/derminator/archipelobby/multiserver/ProcessMultiServerManagerTest.kt
+++ b/src/test/kotlin/com/github/derminator/archipelobby/multiserver/ProcessMultiServerManagerTest.kt
@@ -4,17 +4,20 @@ import com.github.derminator.archipelobby.data.Room
 import com.github.derminator.archipelobby.data.RoomRepository
 import com.github.derminator.archipelobby.generator.PythonScriptRunner
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
+import org.springframework.web.server.ResponseStatusException
 import reactor.core.publisher.Mono
 import java.net.ServerSocket
 import java.nio.file.Path
 import kotlin.io.path.writeText
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -27,6 +30,7 @@ class ProcessMultiServerManagerTest {
         script.writeText(
             """
             import socket
+            import os
             import sys
             import time
 
@@ -36,6 +40,7 @@ class ProcessMultiServerManagerTest {
                 server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
                 server.bind(("127.0.0.1", port))
                 server.listen()
+                print("ARCHIPELOBBY_READY=" + os.environ["ARCHIPELOBBY_READY_TOKEN"], flush=True)
                 time.sleep(10)
             """.trimIndent(),
         )
@@ -71,4 +76,100 @@ class ProcessMultiServerManagerTest {
             manager.stopServer(1L)
         }
     }
+
+    @Test
+    fun `occupied ports are not allocated`(@TempDir tempDir: Path) = runBlocking {
+        ServerSocket(0).use { occupied ->
+            val roomRepository = generatedRoomRepository(1L)
+            val properties = MultiServerProperties(
+                portRangeStart = occupied.localPort,
+                portRangeEnd = occupied.localPort,
+                bindHost = "127.0.0.1",
+                scriptPath = tempDir.resolve("MultiServer.py").toString(),
+                wrapperScriptPath = tempDir.resolve("unused.py").toString(),
+            )
+            val manager = manager(properties, roomRepository)
+
+            assertFailsWith<ResponseStatusException> { manager.startServer(1L) }
+            assertTrue(!manager.isRunning(1L))
+        }
+    }
+
+    @Test
+    fun `port remains allocated until stopped process exits`(@TempDir tempDir: Path) = runBlocking {
+        val port = ServerSocket(0).use { it.localPort }
+        val script = tempDir.resolve("slow_stop_server.py")
+        script.writeText(
+            """
+            import os
+            import signal
+            import socket
+            import sys
+            import time
+
+            port = int(sys.argv[sys.argv.index("--port") + 1])
+            server = socket.socket()
+            server.bind(("127.0.0.1", port))
+            server.listen()
+            print("ARCHIPELOBBY_READY=" + os.environ["ARCHIPELOBBY_READY_TOKEN"], flush=True)
+
+            def stop(*_):
+                server.close()
+                time.sleep(1.5)
+                sys.exit(0)
+
+            signal.signal(signal.SIGTERM, stop)
+            time.sleep(10)
+            """.trimIndent(),
+        )
+        val roomRepository = generatedRoomRepository(1L, 2L)
+        val properties = MultiServerProperties(
+            portRangeStart = port,
+            portRangeEnd = port,
+            host = "127.0.0.1",
+            scriptPath = tempDir.resolve("MultiServer.py").toString(),
+            wrapperScriptPath = script.toString(),
+        )
+        val manager = manager(properties, roomRepository)
+
+        try {
+            manager.startServer(1L)
+            withTimeout(5_000) {
+                while (manager.getServerPort(1L) == null) delay(25)
+            }
+            val stopping = launch { manager.stopServer(1L) }
+            delay(250)
+
+            assertFailsWith<ResponseStatusException> { manager.startServer(2L) }
+            stopping.join()
+            manager.startServer(2L)
+            assertTrue(manager.isRunning(2L))
+        } finally {
+            manager.stopServer(1L)
+            manager.stopServer(2L)
+        }
+    }
+
+    @Test
+    fun `bind host defaults to the established host setting`() {
+        assertEquals("0.0.0.0", MultiServerProperties(host = "0.0.0.0").bindHost)
+    }
+
+    private fun generatedRoomRepository(vararg roomIds: Long): RoomRepository {
+        val repository = mock(RoomRepository::class.java)
+        roomIds.forEach { roomId ->
+            `when`(repository.findById(roomId)).thenReturn(
+                Mono.just(Room(roomId, 123L, "Room $roomId", generatedGameFilePath = "game.archipelago")),
+            )
+        }
+        return repository
+    }
+
+    private fun manager(properties: MultiServerProperties, roomRepository: RoomRepository) =
+        ProcessMultiServerManager(
+            properties,
+            roomRepository,
+            PythonScriptRunner("python3"),
+            InternalToken(properties),
+        )
 }


### PR DESCRIPTION
Closes #88

## Summary

Adds direct per-room MultiServer WebSocket addresses for clients that cannot use subpaths.

- Allocates each room a port from `38281-38380` and displays `ws://<public-host>:<port>` alongside the existing `/rooms/<id>/ws` proxy address.
- Keeps rooms in a `Starting` state until the child MultiServer confirms it has successfully bound its listener, preventing premature address advertisement.
- Skips ports already occupied by other processes and retains allocations until stopped child processes exit.
- Separates the internal proxy host, child-process bind host, and player-facing public hostname. Production binds MultiServers to `0.0.0.0`; `ARCHIPELOBBY_MULTISERVER_PUBLIC_HOST` controls the advertised hostname.
- Documents Docker port publishing, firewall requirements, k3s LoadBalancer/NodePort configuration, Cloudflare limitations for arbitrary ports, and a hostname-routing follow-up plan via Cloudflare Tunnel and wildcard hosts.

## Testing

Adds coverage for wrapper readiness reporting, room-page running/starting/stopped states, direct address rendering, occupied-port handling, readiness gating, and port retention during shutdown.

_Implemented by ai-harness._